### PR TITLE
変数不一致項目の修正

### DIFF
--- a/strings.po
+++ b/strings.po
@@ -7754,7 +7754,7 @@ msgstr "バークレー"
 #. STRINGS.DUPLICANTS.PERSONALITIES.JOSHUA.DESC
 msgctxt "STRINGS.DUPLICANTS.PERSONALITIES.JOSHUA.DESC"
 msgid "{0}s are precious goobers. Other Duplicants are strangely incapable of cursing in a {0}'s presence."
-msgstr "{0} は貴重なお馬鹿さんです。奇妙なことに、他の複製人間達は彼を馬鹿にすることを許しません。"
+msgstr "{0} は貴重なお馬鹿さんです。奇妙なことに、他の複製人間達は {0} を馬鹿にすることを許しません。"
 
 #. STRINGS.DUPLICANTS.PERSONALITIES.JOSHUA.NAME
 msgctxt "STRINGS.DUPLICANTS.PERSONALITIES.JOSHUA.NAME"
@@ -13024,7 +13024,8 @@ msgid ""
 "{0}"
 msgstr ""
 "格納タイプが定義されていません。\n"
-"これらのアイテムを格納するために<color=#833A5FFF>格納庫ツール</color><color=#F44A47>[Y]</color>を使いましょう:"
+"これらのアイテムを格納するために<color=#833A5FFF>格納庫ツール</color><color=#F44A47>[Y]</color>を使いましょう:\n"
+"{0}"
 
 #. STRINGS.MISC.NOTIFICATIONS.OUTPUTBLOCKED.NAME
 msgctxt "STRINGS.MISC.NOTIFICATIONS.OUTPUTBLOCKED.NAME"
@@ -13450,7 +13451,7 @@ msgstr "{Mass}"
 #. STRINGS.MISC.STATUSITEMS.ELEMENTALMASS.TOOLTIP
 msgctxt "STRINGS.MISC.STATUSITEMS.ELEMENTALMASS.TOOLTIP"
 msgid "The selected item has a mass of {Mass}"
-msgstr "選択しているアイテムの質量は {0} です"
+msgstr "選択しているアイテムの質量は {Mass} です"
 
 #. STRINGS.MISC.STATUSITEMS.ELEMENTALTEMPERATURE.NAME
 msgctxt "STRINGS.MISC.STATUSITEMS.ELEMENTALTEMPERATURE.NAME"
@@ -13460,7 +13461,7 @@ msgstr "{Temp}"
 #. STRINGS.MISC.STATUSITEMS.ELEMENTALTEMPERATURE.TOOLTIP
 msgctxt "STRINGS.MISC.STATUSITEMS.ELEMENTALTEMPERATURE.TOOLTIP"
 msgid "The selected item is currently {Temp}"
-msgstr "選択しているアイテムの温度は {0} です"
+msgstr "選択しているアイテムの温度は {Temp} です"
 
 #. STRINGS.MISC.STATUSITEMS.HEALTHSTATUS.CRITICAL.NAME
 msgctxt "STRINGS.MISC.STATUSITEMS.HEALTHSTATUS.CRITICAL.NAME"
@@ -16158,12 +16159,12 @@ msgstr "<style=\"heat\">冷却要素: </style>: <style=\"produced\">{0}</style>"
 #. STRINGS.UI.BUILDINGEFFECTS.HEATCONSUMED
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.HEATCONSUMED"
 msgid "<style=\"heat\">Heat</style>: <style=\"consumed\">-{0}</style>"
-msgstr "少量の<style=\"heat\">熱</style>を散らします。"
+msgstr "<style=\"heat\">発熱</style>: <style=\"consumed\">-{0}</style>"
 
 #. STRINGS.UI.BUILDINGEFFECTS.HEATGENERATED
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.HEATGENERATED"
 msgid "<style=\"heat\">Heat</style>: <style=\"produced\">+{0}</style>"
-msgstr "少量の<style=\"heat\">熱</style>を散らします。"
+msgstr "<style=\"heat\">発熱</style>: <style=\"produced\">+{0}</style>"
 
 #. STRINGS.UI.BUILDINGEFFECTS.HIT_POINTS_PER_CYCLE
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.HIT_POINTS_PER_CYCLE"
@@ -16687,7 +16688,7 @@ msgstr "<b>{0}</b>の全ての食事許可を切り替えます"
 #. STRINGS.UI.CONTEXTSCREEN.ASSIGNEDTO
 msgctxt "STRINGS.UI.CONTEXTSCREEN.ASSIGNEDTO"
 msgid "Assigned To:"
-msgstr "担当: {Assignee}"
+msgstr "割り当て:"
 
 #. STRINGS.UI.CONTEXTSCREEN.PRECONDITIONS.CANCHAT
 msgctxt "STRINGS.UI.CONTEXTSCREEN.PRECONDITIONS.CANCHAT"
@@ -18460,7 +18461,7 @@ msgstr "最初の成長: {0}"
 #. STRINGS.UI.GAMEOBJECTEFFECTS.LIFECYCLETITLE
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.LIFECYCLETITLE"
 msgid "Growth:"
-msgstr "成長: {0}"
+msgstr "成長:"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.PLANT_DO_NOT_HARVEST
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.PLANT_DO_NOT_HARVEST"
@@ -20547,7 +20548,7 @@ msgstr "複製人間が到達可能なエリアを表示します"
 #. STRINGS.UI.TOOLTIPS.RECIPE_QUEUE
 msgctxt "STRINGS.UI.TOOLTIPS.RECIPE_QUEUE"
 msgid "Queue 1 {0} for fabrication"
-msgstr "作成するものをセットしてください"
+msgstr "{0} をセットしてください"
 
 #. STRINGS.UI.TOOLTIPS.RECIPE_QUEUE_INFINITE
 msgctxt "STRINGS.UI.TOOLTIPS.RECIPE_QUEUE_INFINITE"
@@ -20793,7 +20794,7 @@ msgstr "(所有者)"
 #. STRINGS.UI.UISIDESCREENS.ASSIGNABLESIDESCREEN.NEEDSREGION
 msgctxt "STRINGS.UI.UISIDESCREENS.ASSIGNABLESIDESCREEN.NEEDSREGION"
 msgid "This {0} needs to be inside a {1} region"
-msgstr "この設備は {0} の中でなければなりません"
+msgstr "この {0} は {1} の中でなければなりません"
 
 #. STRINGS.UI.UISIDESCREENS.ASSIGNABLESIDESCREEN.NEEDSREGIONS
 msgctxt "STRINGS.UI.UISIDESCREENS.ASSIGNABLESIDESCREEN.NEEDSREGIONS"
@@ -21192,7 +21193,7 @@ msgstr "{0} 点以上の収穫レート点数がある状態で成熟した場�
 #. STRINGS.UI.UISIDESCREENS.PLANTERSIDESCREEN.TOOLTIPS.NUMBEROFHARVESTS
 msgctxt "STRINGS.UI.UISIDESCREENS.PLANTERSIDESCREEN.TOOLTIPS.NUMBEROFHARVESTS"
 msgid "This plant will yield {0} harvests in its lifecycle"
-msgstr "この植物は枯れるまでにあと {HarvestsRemaining} 回収穫できます"
+msgstr "この植物は枯れるまでにあと {0} 回収穫できます"
 
 #. STRINGS.UI.UISIDESCREENS.PLANTERSIDESCREEN.TOOLTIPS.OPTIMUMCONDITIONS
 msgctxt "STRINGS.UI.UISIDESCREENS.PLANTERSIDESCREEN.TOOLTIPS.OPTIMUMCONDITIONS"


### PR DESCRIPTION
output_log.txt 内に翻訳のパースエラー項目が表示されているのを見つけましたので、それを修正しました。実際のゲーム内での修正後の確認はしていませんが、ログのエラー表示は出なくなりました。

一か所、Assigned To の「担当」を別の場所では「割り当て」が使われているので「割り当て」に統一してみたのですが、もしまずければ元に戻してください。
