### PR TITLE
UIカテゴリの翻訳

### DIFF
--- a/po/ui.po
+++ b/po/ui.po
@@ -79,12 +79,9 @@ msgid "<link=\"BUILDCATEGORYAUTOMATION\">Automation</link>"
 msgstr "<link=\"BUILDCATEGORYAUTOMATION\">自動化</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.AUTOMATION.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.AUTOMATION.TOOLTIP"
-#| msgid "Automate my base with logic circuits and sensors."
 msgctxt "STRINGS.UI.BUILDCATEGORIES.AUTOMATION.TOOLTIP"
 msgid "Automate my base with logic circuits and sensors. {Hotkey}"
-msgstr "論理回路やセンサーで、基地を自動化しましょう。"
+msgstr "論理回路やセンサーで、基地を自動化しましょう。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.BASE.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.BASE.NAME"
@@ -92,13 +89,10 @@ msgid "<link=\"BUILDCATEGORYBASE\">Base</link>"
 msgstr "<link=\"BUILDCATEGORYBASE\">基地</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.BASE.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.BASE.TOOLTIP"
-#| msgid "Maintain the colony's infrastructure with these homebase basics."
 msgctxt "STRINGS.UI.BUILDCATEGORIES.BASE.TOOLTIP"
 msgid ""
 "Maintain the colony's infrastructure with these homebase basics. {Hotkey}"
-msgstr "これらの基本的な土台でコロニーのインフラを支えましょう。"
+msgstr "これらの基本的な土台でコロニーのインフラを支えましょう。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.CONVEYANCE.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.CONVEYANCE.NAME"
@@ -106,12 +100,9 @@ msgid "<link=\"BUILDCATEGORYCONVEYANCE\">Shipping</link>"
 msgstr "<link=\"BUILDCATEGORYCONVEYANCE\">輸送</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.CONVEYANCE.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.CONVEYANCE.TOOLTIP"
-#| msgid "Effortlessly transport ore and solid materials around my base."
 msgctxt "STRINGS.UI.BUILDCATEGORIES.CONVEYANCE.TOOLTIP"
 msgid "Effortlessly transport ore and solid materials around my base. {Hotkey}"
-msgstr "鉱石や固体素材を楽々と基地に輸送しましょう。"
+msgstr "鉱石や固体素材を楽々と基地に輸送しましょう。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.EQUIPMENT.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.EQUIPMENT.NAME"
@@ -119,12 +110,9 @@ msgid "<link=\"BUILDCATEGORYEQUIPMENT\">Stations</link>"
 msgstr "<link=\"BUILDCATEGORYEQUIPMENT\">端末</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.EQUIPMENT.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.EQUIPMENT.TOOLTIP"
-#| msgid "Unlock new technologies through the power of science!"
 msgctxt "STRINGS.UI.BUILDCATEGORIES.EQUIPMENT.TOOLTIP"
 msgid "Unlock new technologies through the power of science! {Hotkey}"
-msgstr "科学の力で新しい技術を手に入れましょう！"
+msgstr "科学の力で新しい技術を手に入れましょう！{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.FOOD.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.FOOD.NAME"
@@ -132,12 +120,9 @@ msgid "<link=\"BUILDCATEGORYFOOD\">Food</link>"
 msgstr "<link=\"BUILDCATEGORYFOOD\">食糧</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.FOOD.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.FOOD.TOOLTIP"
-#| msgid "Keep my Duplicants' spirits high and their bellies full."
 msgctxt "STRINGS.UI.BUILDCATEGORIES.FOOD.TOOLTIP"
 msgid "Keep my Duplicants' spirits high and their bellies full. {Hotkey}"
-msgstr "複製人間の心と胃袋を満たしましょう。"
+msgstr "複製人間の心と胃袋を満たしましょう。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.FURNITURE.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.FURNITURE.NAME"
@@ -145,12 +130,9 @@ msgid "<link=\"BUILDCATEGORYFURNITURE\">Furniture</link>"
 msgstr "<link=\"BUILDCATEGORYFURNITURE\">家具</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.FURNITURE.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.FURNITURE.TOOLTIP"
-#| msgid "Amenities to keep my Duplicants happy, comfy and efficient."
 msgctxt "STRINGS.UI.BUILDCATEGORIES.FURNITURE.TOOLTIP"
 msgid "Amenities to keep my Duplicants happy, comfy and efficient. {Hotkey}"
-msgstr "複製人間が幸せで快適に効率よく生活するためのアメニティです。"
+msgstr "複製人間が幸せで快適に効率よく生活するためのアメニティです。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.HVAC.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.HVAC.NAME"
@@ -158,12 +140,9 @@ msgid "<link=\"BUILDCATEGORYHVAC\">Ventilation</link>"
 msgstr "<link=\"BUILDCATEGORYHVAC\">換気</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.HVAC.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.HVAC.TOOLTIP"
-#| msgid "Control the flow of gas in the base."
 msgctxt "STRINGS.UI.BUILDCATEGORIES.HVAC.TOOLTIP"
 msgid "Control the flow of gas in the base. {Hotkey}"
-msgstr "基地における気体の流れを制御します。"
+msgstr "基地における気体の流れを制御します。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.MEDICAL.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.MEDICAL.NAME"
@@ -171,12 +150,9 @@ msgid "<link=\"BUILDCATEGORYMEDICAL\">Medicine</link>"
 msgstr "<link=\"BUILDCATEGORYMEDICAL\">医療</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.MEDICAL.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.MEDICAL.TOOLTIP"
-#| msgid "A cure for everything but the common cold."
 msgctxt "STRINGS.UI.BUILDCATEGORIES.MEDICAL.TOOLTIP"
 msgid "A cure for everything but the common cold. {Hotkey}"
-msgstr "風邪以外なら何でも治します。"
+msgstr "風邪以外なら何でも治します。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.MISC.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.MISC.NAME"
@@ -184,12 +160,9 @@ msgid "<link=\"BUILDCATEGORYMISC\">Decor</link>"
 msgstr "<link=\"BUILDCATEGORYMISC\">装飾</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.MISC.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.MISC.TOOLTIP"
-#| msgid "Spruce up my colony with some lovely interior decorating."
 msgctxt "STRINGS.UI.BUILDCATEGORIES.MISC.TOOLTIP"
 msgid "Spruce up my colony with some lovely interior decorating. {Hotkey}"
-msgstr "素敵なインテリアでコロニーを飾りましょう。"
+msgstr "素敵なインテリアでコロニーを飾りましょう。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.OXYGEN.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.OXYGEN.NAME"
@@ -197,12 +170,9 @@ msgid "<link=\"BUILDCATEGORYOXYGEN\">Oxygen</link>"
 msgstr "<link=\"BUILDCATEGORYOXYGEN\">酸素</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.OXYGEN.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.OXYGEN.TOOLTIP"
-#| msgid "Everything I need to keep the colony breathing."
 msgctxt "STRINGS.UI.BUILDCATEGORIES.OXYGEN.TOOLTIP"
 msgid "Everything I need to keep the colony breathing. {Hotkey}"
-msgstr "コロニー内で呼吸するために必要なものが揃っています。"
+msgstr "コロニー内で呼吸するために必要なものが揃っています。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.PLUMBING.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.PLUMBING.NAME"
@@ -210,12 +180,9 @@ msgid "<link=\"BUILDCATEGORYPLUMBING\">Plumbing</link>"
 msgstr "<link=\"BUILDCATEGORYPLUMBING\">配管</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.PLUMBING.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.PLUMBING.TOOLTIP"
-#| msgid "Get the colony's water running and its sewage flowing."
 msgctxt "STRINGS.UI.BUILDCATEGORIES.PLUMBING.TOOLTIP"
 msgid "Get the colony's water running and its sewage flowing. {Hotkey}"
-msgstr "上水下水の制御をします。"
+msgstr "上水下水の制御をします。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.POWER.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.POWER.NAME"
@@ -223,12 +190,9 @@ msgid "<link=\"BUILDCATEGORYPOWER\">Power</link>"
 msgstr "<link=\"BUILDCATEGORYPOWER\">電力</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.POWER.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.POWER.TOOLTIP"
-#| msgid "Need to power the colony? Here's how to do it!"
 msgctxt "STRINGS.UI.BUILDCATEGORIES.POWER.TOOLTIP"
 msgid "Need to power the colony? Here's how to do it! {Hotkey}"
-msgstr "コロニーに電力が必要ですか？これをどうぞ！"
+msgstr "コロニーに電力が必要ですか？これをどうぞ！{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.REFINING.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.REFINING.NAME"
@@ -236,12 +200,9 @@ msgid "<link=\"BUILDCATEGORYREFINING\">Refinement</link>"
 msgstr "<link=\"BUILDCATEGORYREFINING\">精製</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.REFINING.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.REFINING.TOOLTIP"
-#| msgid "Use the resources I want, filter the ones I don't."
 msgctxt "STRINGS.UI.BUILDCATEGORIES.REFINING.TOOLTIP"
 msgid "Use the resources I want, filter the ones I don't. {Hotkey}"
-msgstr "いらないものはろ過して、欲しいものだけ使いましょう。"
+msgstr "いらないものはろ過して、欲しいものだけ使いましょう。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.ROCKETRY.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.ROCKETRY.NAME"
@@ -249,12 +210,9 @@ msgid "<link=\"BUILDCATEGORYROCKETRY\">Rocketry</link>"
 msgstr "<link=\"BUILDCATEGORYROCKETRY\">ロケット工学</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.ROCKETRY.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.ROCKETRY.TOOLTIP"
-#| msgid "Rocketry"
 msgctxt "STRINGS.UI.BUILDCATEGORIES.ROCKETRY.TOOLTIP"
 msgid "Rocketry {Hotkey}"
-msgstr "ロケット工学"
+msgstr "ロケット工学{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.UTILITIES.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.UTILITIES.NAME"
@@ -262,12 +220,9 @@ msgid "<link=\"BUILDCATEGORYUTILITIES\">Utilities</link>"
 msgstr "<link=\"BUILDCATEGORYUTILITIES\">その他</link>"
 
 #. STRINGS.UI.BUILDCATEGORIES.UTILITIES.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.UTILITIES.TOOLTIP"
-#| msgid "Heat up and cool down."
 msgctxt "STRINGS.UI.BUILDCATEGORIES.UTILITIES.TOOLTIP"
 msgid "Heat up and cool down. {Hotkey}"
-msgstr "温めたり、冷やしたりします。"
+msgstr "温めたり、冷やしたりします。{Hotkey}"
 
 #. STRINGS.UI.BUILDINGEFFECTS.ADDED_EFFECT
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.ADDED_EFFECT"
@@ -1245,9 +1200,6 @@ msgid "Cancel"
 msgstr "キャンセル"
 
 #. STRINGS.UI.CAREPACKAGECONTAINER_INFORMATION_TITLE
-#, fuzzy
-#| msgctxt "STRINGS.UI.DETAILTABS.SIMPLEINFO.GROUPNAME_DESCRIPTION"
-#| msgid "INFORMATION"
 msgctxt "STRINGS.UI.CAREPACKAGECONTAINER_INFORMATION_TITLE"
 msgid "INFORMATION"
 msgstr "情報"
@@ -1681,12 +1633,9 @@ msgid "Copy"
 msgstr "コピー"
 
 #. STRINGS.UI.COPY_BUILDING_TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.COPY_BUILDING_TOOLTIP"
-#| msgid "Create new build orders for the selected building."
 msgctxt "STRINGS.UI.COPY_BUILDING_TOOLTIP"
 msgid "Create new build orders for the selected building. {Hotkey}"
-msgstr "選択している建物を新たに建設します。"
+msgstr "選択している建物を新たに建設します。{Hotkey}"
 
 #. STRINGS.UI.CRAFT
 msgctxt "STRINGS.UI.CRAFT"
@@ -1986,20 +1935,14 @@ msgid "Demo time remaining"
 msgstr "デモ時間の残り"
 
 #. STRINGS.UI.DETAILTABS.BUILDING_CHORES.AVAILABLE_CHORES
-#, fuzzy
-#| msgctxt "STRINGS.BUILDING.STATUSITEMS.WATTSON.UNAVAILABLE"
-#| msgid "UNAVAILABLE"
 msgctxt "STRINGS.UI.DETAILTABS.BUILDING_CHORES.AVAILABLE_CHORES"
 msgid "AVAILABLE ERRANDS"
-msgstr "利用不可"
+msgstr "可能な作業"
 
 #. STRINGS.UI.DETAILTABS.BUILDING_CHORES.DUPE_TOOLTIP_DESC_ACTIVE
-#, fuzzy
-#| msgctxt "STRINGS.UI.DETAILTABS.PERSONALITY.RESUME.CURRENT_ROLE.TOOLTIP"
-#| msgid "{0} is currently working as a {1}"
 msgctxt "STRINGS.UI.DETAILTABS.BUILDING_CHORES.DUPE_TOOLTIP_DESC_ACTIVE"
 msgid "{Name} is currently working on '{Errand}'."
-msgstr "{0}は現在{1}として働いています"
+msgstr "{Name}は現在'{Errand}'の作業をしています。"
 
 #. STRINGS.UI.DETAILTABS.BUILDING_CHORES.DUPE_TOOLTIP_DESC_INACTIVE
 msgctxt "STRINGS.UI.DETAILTABS.BUILDING_CHORES.DUPE_TOOLTIP_DESC_INACTIVE"
@@ -2007,6 +1950,8 @@ msgid ""
 "'{Errand}' is #{Rank} on {Name}'s To Do list, after they finish their "
 "current errand."
 msgstr ""
+"'{Errand}' の作業は、現在の作業の完了後、 {Name}のTo Doリストの{Rank}番目で"
+"す。"
 
 #. STRINGS.UI.DETAILTABS.BUILDING_CHORES.DUPE_TOOLTIP_FAILED
 msgctxt "STRINGS.UI.DETAILTABS.BUILDING_CHORES.DUPE_TOOLTIP_FAILED"
@@ -2014,6 +1959,8 @@ msgid ""
 "{Name} can't do {Errand} right now. Reason:\n"
 "{FailedPrecondition}"
 msgstr ""
+"{Name}は現在{Errand}の作業が出来ません。理由:\n"
+"{FailedPrecondition}"
 
 #. STRINGS.UI.DETAILTABS.BUILDING_CHORES.DUPE_TOOLTIP_SUCCEEDED
 msgctxt "STRINGS.UI.DETAILTABS.BUILDING_CHORES.DUPE_TOOLTIP_SUCCEEDED"
@@ -2028,19 +1975,25 @@ msgid ""
 "\n"
 "Total Priority: {TotalPriority}"
 msgstr ""
+"{Description}\n"
+"\n"
+"{Errand}の作業の種類: {Groups}\n"
+"\n"
+"{Name}の{BestGroup}の優先度: {PersonalPriorityValue} ({PersonalPriority})\n"
+"{Building}の優先度: {BuildingPriority}\n"
+"全ての{BestGroup}の作業: {TypePriority}\n"
+"\n"
+"全体の優先度: {TotalPriority}"
 
 #. STRINGS.UI.DETAILTABS.BUILDING_CHORES.NAME
-#, fuzzy
-#| msgctxt "STRINGS.MISC.STATUSITEMS.WAITINGFORDIG.NAME"
-#| msgid "Dig Errand"
 msgctxt "STRINGS.UI.DETAILTABS.BUILDING_CHORES.NAME"
 msgid "Errands"
-msgstr "採掘作業"
+msgstr "作業"
 
 #. STRINGS.UI.DETAILTABS.BUILDING_CHORES.TOOLTIP
 msgctxt "STRINGS.UI.DETAILTABS.BUILDING_CHORES.TOOLTIP"
 msgid "See what errands this building has waiting to be done"
-msgstr ""
+msgstr "この建物の完了待ちの作業を見る"
 
 #. STRINGS.UI.DETAILTABS.DETAILS.CONTENTS_DISEASED
 msgctxt "STRINGS.UI.DETAILTABS.DETAILS.CONTENTS_DISEASED"
@@ -3274,12 +3227,9 @@ msgid "Added"
 msgstr "増加"
 
 #. STRINGS.UI.ENDOFDAYREPORT.BASE_DETAILS_HEADER
-#, fuzzy
-#| msgctxt "STRINGS.UI.CODEX.DETAILS"
-#| msgid "Details"
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.BASE_DETAILS_HEADER"
 msgid "Base Details:"
-msgstr "詳細"
+msgstr "基地の詳細:"
 
 #. STRINGS.UI.ENDOFDAYREPORT.CALORIES_CREATED.NAME
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.CALORIES_CREATED.NAME"
@@ -3303,25 +3253,17 @@ msgstr "コロニーは一日を通して<link=\"FOOD\">食糧</link>を{0}生�
 #. STRINGS.UI.ENDOFDAYREPORT.CHORE_STATUS.NAME
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.CHORE_STATUS.NAME"
 msgid "Chores:"
-msgstr ""
+msgstr "作業"
 
 #. STRINGS.UI.ENDOFDAYREPORT.CHORE_STATUS.NEGATIVE_TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.ENDOFDAYREPORT.TIME_SPENT.POSITIVE_TOOLTIP"
-#| msgid ""
-#| "My Duplicants spent a total of {0} doing errands over the course of the "
-#| "day"
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.CHORE_STATUS.NEGATIVE_TOOLTIP"
 msgid "My Duplicants completed {0} chores over the course of the day"
-msgstr "複製人間は一日を通して合計{0}作業していました"
+msgstr "複製人間は一日を通して合計{0}の作業を完了しました"
 
 #. STRINGS.UI.ENDOFDAYREPORT.CHORE_STATUS.POSITIVE_TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.ENDOFDAYREPORT.DISEASE_STATUS.TOOLTIP"
-#| msgid "My Duplicants are covered in {0}"
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.CHORE_STATUS.POSITIVE_TOOLTIP"
 msgid "My Duplicants have chores outstanding {0}"
-msgstr "複製人間は {0} に覆われています"
+msgstr "複製人間の残作業の数は{0}です"
 
 #. STRINGS.UI.ENDOFDAYREPORT.CONTAMINATED_OXYGEN_FLATULENCE.NAME
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.CONTAMINATED_OXYGEN_FLATULENCE.NAME"
@@ -3437,12 +3379,9 @@ msgid "My Duplicants are covered in {0}"
 msgstr "複製人間は {0} に覆われています"
 
 #. STRINGS.UI.ENDOFDAYREPORT.DUPLICANT_DETAILS_HEADER
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDINGEFFECTS.REQUIRESMANUALOPERATION"
-#| msgid "Duplicant operation"
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.DUPLICANT_DETAILS_HEADER"
 msgid "Duplicant Details:"
-msgstr "複製人間の操作"
+msgstr "複製人間の詳細:"
 
 #. STRINGS.UI.ENDOFDAYREPORT.ENERGY_USAGE.NAME
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.ENERGY_USAGE.NAME"
@@ -3490,7 +3429,7 @@ msgstr "待機時間:"
 #. STRINGS.UI.ENDOFDAYREPORT.IDLE_TIME.POSITIVE_TOOLTIP
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.IDLE_TIME.POSITIVE_TOOLTIP"
 msgid "On average, my Duplicants {0} of their time idling"
-msgstr ""
+msgstr "平均して、複製人間は自分の時間の{0}待機しています"
 
 #. STRINGS.UI.ENDOFDAYREPORT.LEVEL_UP.NAME
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.LEVEL_UP.NAME"
@@ -3567,9 +3506,6 @@ msgstr ""
 "{1}: {2}"
 
 #. STRINGS.UI.ENDOFDAYREPORT.NOTES.PERSONAL_TIME
-#, fuzzy
-#| msgctxt "STRINGS.ROOMS.CRITERIA.CRITERIA_FAILED.FAILED"
-#| msgid "{0}"
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.NOTES.PERSONAL_TIME"
 msgid "{0}"
 msgstr "{0}"
@@ -3590,9 +3526,6 @@ msgid "{0}"
 msgstr "{0}"
 
 #. STRINGS.UI.ENDOFDAYREPORT.NOTES.WORK_TIME
-#, fuzzy
-#| msgctxt "STRINGS.ROOMS.CRITERIA.CRITERIA_FAILED.FAILED"
-#| msgid "{0}"
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.NOTES.WORK_TIME"
 msgid "{0}"
 msgstr "{0}"
@@ -3627,18 +3560,16 @@ msgid ""
 msgstr "コロニーは一日を通して<link=\"OXYGEN\">酸素</link>を{0}生成しました"
 
 #. STRINGS.UI.ENDOFDAYREPORT.PERSONAL_TIME.NAME
-#, fuzzy
-#| msgctxt "STRINGS.UI.ENDOFDAYREPORT.TRAVEL_TIME.NAME"
-#| msgid "Travel Time:"
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.PERSONAL_TIME.NAME"
 msgid "Personal Time:"
-msgstr "移動時間:"
+msgstr "私的な時間:"
 
 #. STRINGS.UI.ENDOFDAYREPORT.PERSONAL_TIME.POSITIVE_TOOLTIP
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.PERSONAL_TIME.POSITIVE_TOOLTIP"
 msgid ""
 "On average, my Duplicants spent {0} of their time tending to personal needs"
 msgstr ""
+"平均して、複製人間は自分の時間の{0}を個人的な需要に応える為に費やしています"
 
 #. STRINGS.UI.ENDOFDAYREPORT.PREV
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.PREV"
@@ -3673,12 +3604,9 @@ msgstr ""
 "コロニーは一日を通して<link=\"STRESS\">ストレス</link>を合計{0}上昇させました"
 
 #. STRINGS.UI.ENDOFDAYREPORT.TIME_DETAILS_HEADER
-#, fuzzy
-#| msgctxt "STRINGS.UI.UISIDESCREENS.FABRICATORSIDESCREEN.RECIPE_DETAILS"
-#| msgid "Recipe Details"
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.TIME_DETAILS_HEADER"
 msgid "Time Details:"
-msgstr "レシピ詳細"
+msgstr "時間詳細:"
 
 #. STRINGS.UI.ENDOFDAYREPORT.TOILET_INCIDENT.NAME
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.TOILET_INCIDENT.NAME"
@@ -3699,35 +3627,29 @@ msgstr "移動時間:"
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.TRAVEL_TIME.POSITIVE_TOOLTIP"
 msgid ""
 "On average, my Duplicants spent {0} of their time travelling between tasks"
-msgstr ""
+msgstr "平均して、複製人間は自分の時間の{0}をタスク間の移動に費やしています"
 
 #. STRINGS.UI.ENDOFDAYREPORT.TRAVELTIMEWARNING.WARNING_MESSAGE
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.TRAVELTIMEWARNING.WARNING_MESSAGE"
 msgid ""
 "Your Duplicants are spending a significant amount of time travelling between "
 "their errands (> {0})"
-msgstr ""
+msgstr "複製人間は作業間の移動にかなりの時間を費やしています (> {0})"
 
 #. STRINGS.UI.ENDOFDAYREPORT.TRAVELTIMEWARNING.WARNING_TITLE
-#, fuzzy
-#| msgctxt "STRINGS.UI.SPACEDESTINATIONS.COMETS.IRONCOMET.NAME"
-#| msgid "Iron Comet"
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.TRAVELTIMEWARNING.WARNING_TITLE"
 msgid "Long Commutes"
-msgstr "鉄彗星"
+msgstr "長時間通勤"
 
 #. STRINGS.UI.ENDOFDAYREPORT.WORK_TIME.NAME
-#, fuzzy
-#| msgctxt "STRINGS.DUPLICANTS.MODIFIERS.WORKING.NAME"
-#| msgid "Working"
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.WORK_TIME.NAME"
 msgid "Working Time:"
-msgstr "労働中"
+msgstr "労働時間:"
 
 #. STRINGS.UI.ENDOFDAYREPORT.WORK_TIME.POSITIVE_TOOLTIP
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.WORK_TIME.POSITIVE_TOOLTIP"
 msgid "On average, my Duplicants spent {0} of their time working"
-msgstr ""
+msgstr "平均して、複製人間は自分の時間の{0}を労働に費やしています"
 
 #. STRINGS.UI.EQUIPMENTTAB_HELD
 msgctxt "STRINGS.UI.EQUIPMENTTAB_HELD"
@@ -4967,19 +4889,13 @@ msgid "World Generation Key"
 msgstr "ワールド生成キー"
 
 #. STRINGS.UI.FRONTEND.PATCHNOTESSCREEN.BODY
-#, fuzzy
-#| msgctxt "STRINGS.UI.FRONTEND.PATCHNOTESSCREEN.BODY"
-#| msgid ""
-#| "<b>Welcome to the Quality of Life Upgrade Mk I!!</b>\n"
-#| "\n"
-#| "{0}"
 msgctxt "STRINGS.UI.FRONTEND.PATCHNOTESSCREEN.BODY"
 msgid ""
 "<b>Welcome to the Quality of Life Upgrade Mk II!!</b>\n"
 "\n"
 "{0}"
 msgstr ""
-"<b>QoL アップグレード第一弾にようこそ！！</b>\n"
+"<b>QoL アップグレード第二弾にようこそ！！</b>\n"
 "\n"
 "{0}"
 
@@ -4989,19 +4905,6 @@ msgid "OK"
 msgstr "OK"
 
 #. STRINGS.UI.FRONTEND.PATCHNOTESSCREEN.PATCHNOTES
-#, fuzzy
-#| msgctxt "STRINGS.UI.FRONTEND.PATCHNOTESSCREEN.PATCHNOTES"
-#| msgid ""
-#| "<b>Update Features:</b>\n"
-#| "\n"
-#| "• New Decor items and updated Artist job roles for more decor "
-#| "possibilities\n"
-#| "• Redesigned recipe queue controls for improved item fabrication "
-#| "automation\n"
-#| "• Many, many bug fixes, optimizations, polish passes, updated animations "
-#| "and more!\n"
-#| "\n"
-#| "Please view the full patch notes for further details!"
 msgctxt "STRINGS.UI.FRONTEND.PATCHNOTESSCREEN.PATCHNOTES"
 msgid ""
 "<b>Update Features:</b>\n"
@@ -5016,19 +4919,17 @@ msgid ""
 msgstr ""
 "<b>更新された機能:</b>\n"
 "\n"
-"•新たな装飾品と芸術職の役割の更新による更なる装飾の可能性\n"
-"•レシピのキュー管理の再設計によるアイテム製造自動化の改善\n"
+"•新しいUIツールによる複製人間の優先度の表示、管理\n"
+"•宇宙探検で入手可能な新しいアーティファクト\n"
+"•製造ポッドは複製人間以外に物質も製造可能に\n"
 "•多くの、多くのバグ修正、最適化、経路の洗練、アニメーションの更新等々！\n"
 "\n"
 "更なる詳細については完全なパッチノートを参照してください！"
 
 #. STRINGS.UI.FRONTEND.PATCHNOTESSCREEN.TITLE
-#, fuzzy
-#| msgctxt "STRINGS.UI.FRONTEND.PATCHNOTESSCREEN.TITLE"
-#| msgid "QUALITY OF LIFE UPGRADE MK I"
 msgctxt "STRINGS.UI.FRONTEND.PATCHNOTESSCREEN.TITLE"
 msgid "QUALITY OF LIFE UPGRADE MK II"
-msgstr "QoL アップグレード第一弾"
+msgstr "QoL アップグレード第二弾"
 
 #. STRINGS.UI.FRONTEND.PAUSE_SCREEN.DESKTOPQUIT
 msgctxt "STRINGS.UI.FRONTEND.PAUSE_SCREEN.DESKTOPQUIT"
@@ -5992,41 +5893,26 @@ msgid "Cancel"
 msgstr "キャンセル"
 
 #. STRINGS.UI.IMMIGRANTSCREEN.CARE_PACKAGE_ELEMENT_COUNT
-#, fuzzy
-#| msgctxt "STRINGS.UI.NAME_WITH_UNITS"
-#| msgid "{0} x {1}"
 msgctxt "STRINGS.UI.IMMIGRANTSCREEN.CARE_PACKAGE_ELEMENT_COUNT"
 msgid "{0} x {1}"
 msgstr "{0} x {1}"
 
 #. STRINGS.UI.IMMIGRANTSCREEN.CARE_PACKAGE_ELEMENT_QUANTITY
-#, fuzzy
-#| msgctxt "STRINGS.UI.UISIDESCREENS.REFINERYSIDESCREEN.RECIPE_FROM_TO"
-#| msgid "{0} to {1}"
 msgctxt "STRINGS.UI.IMMIGRANTSCREEN.CARE_PACKAGE_ELEMENT_QUANTITY"
 msgid "{0} of {1}"
-msgstr "{0}から{1}"
+msgstr "{1}の{0}"
 
 #. STRINGS.UI.IMMIGRANTSCREEN.CONFIRMATIONBODY
-#, fuzzy
-#| msgctxt "STRINGS.UI.IMMIGRANTSCREEN.CONFIRMATIONBODY"
-#| msgid ""
-#| "The Printing Pod will need time to recharge if I return these Duplicants "
-#| "to ooze."
 msgctxt "STRINGS.UI.IMMIGRANTSCREEN.CONFIRMATIONBODY"
 msgid ""
 "The Printing Pod will need time to recharge if I reject these Printables."
 msgstr ""
-"これらの複製人間を全て土に還すと、製造ポッドが再び使用可能になるまで待たねば"
-"ならない。"
+"これらの全ての製造物を拒否すると、製造ポッドが再充電する時間が必要になる。"
 
 #. STRINGS.UI.IMMIGRANTSCREEN.CONFIRMATIONTITLE
-#, fuzzy
-#| msgctxt "STRINGS.UI.IMMIGRANTSCREEN.CONFIRMATIONTITLE"
-#| msgid "Reject All Duplicants?"
 msgctxt "STRINGS.UI.IMMIGRANTSCREEN.CONFIRMATIONTITLE"
 msgid "Reject All Printables?"
-msgstr "複製人間を全て拒否しますか？"
+msgstr "全ての製造物を拒否しますか？"
 
 #. STRINGS.UI.IMMIGRANTSCREEN.EMBARK
 msgctxt "STRINGS.UI.IMMIGRANTSCREEN.EMBARK"
@@ -6034,12 +5920,9 @@ msgid "EMBARK"
 msgstr "送り出す"
 
 #. STRINGS.UI.IMMIGRANTSCREEN.IMMIGRANTSCREENTITLE
-#, fuzzy
-#| msgctxt "STRINGS.UI.IMMIGRANTSCREEN.IMMIGRANTSCREENTITLE"
-#| msgid "Select a DNA Blueprint"
 msgctxt "STRINGS.UI.IMMIGRANTSCREEN.IMMIGRANTSCREENTITLE"
 msgid "Select a Blueprint"
-msgstr "DNA設計図選択"
+msgstr "設計図を選択"
 
 #. STRINGS.UI.IMMIGRANTSCREEN.NAME_YOUR_COLONY
 msgctxt "STRINGS.UI.IMMIGRANTSCREEN.NAME_YOUR_COLONY"
@@ -6120,12 +6003,9 @@ msgid "Priority"
 msgstr "優先度"
 
 #. STRINGS.UI.JOBSSCREEN.DECREASE_PRIORITY_TUTORIAL
-#, fuzzy
-#| msgctxt "STRINGS.UI.JOBSSCREEN.DECREASE_PRIORITY_TUTORIAL"
-#| msgid "{Key} Decrease priority"
 msgctxt "STRINGS.UI.JOBSSCREEN.DECREASE_PRIORITY_TUTORIAL"
 msgid "{Hotkey} Decrease priority"
-msgstr "{Key} 優先度を下げる"
+msgstr "{Hotkey}優先度を下げる"
 
 #. STRINGS.UI.JOBSSCREEN.DECREASE_ROW_PRIORITY_MINION_TOOLTIP
 msgctxt "STRINGS.UI.JOBSSCREEN.DECREASE_ROW_PRIORITY_MINION_TOOLTIP"
@@ -6181,12 +6061,9 @@ msgstr ""
 "タスクを選びます"
 
 #. STRINGS.UI.JOBSSCREEN.INCREASE_PRIORITY_TUTORIAL
-#, fuzzy
-#| msgctxt "STRINGS.UI.JOBSSCREEN.INCREASE_PRIORITY_TUTORIAL"
-#| msgid "{Key} Increase priority"
 msgctxt "STRINGS.UI.JOBSSCREEN.INCREASE_PRIORITY_TUTORIAL"
 msgid "{Hotkey} Increase priority"
-msgstr "{Key} 優先度を上げる"
+msgstr "{Hotkey}優先度を上げる"
 
 #. STRINGS.UI.JOBSSCREEN.INCREASE_ROW_PRIORITY_MINION_TOOLTIP
 msgctxt "STRINGS.UI.JOBSSCREEN.INCREASE_ROW_PRIORITY_MINION_TOOLTIP"
@@ -6205,14 +6082,13 @@ msgid ""
 msgstr "{Role}として、{Name}は{Job}作業を優先度{Priority}と見なします"
 
 #. STRINGS.UI.JOBSSCREEN.ITEM_TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.JOBSSCREEN.ITEM_TOOLTIP"
-#| msgid "The {Job} Errand Type is a {Priority} Priority for <b>{Name}</b>"
 msgctxt "STRINGS.UI.JOBSSCREEN.ITEM_TOOLTIP"
 msgid ""
 "{Job} Errand Type for {Name}:\n"
 "<b>{Priority} Priority ({PriorityValue})</b>"
-msgstr "<b>{Name}</b>の{Job}作業は優先度{Priority}です"
+msgstr ""
+"{Name}の{Job}の作業種別:\n"
+"<b>優先度{Priority} ({PriorityValue})</b>"
 
 #. STRINGS.UI.JOBSSCREEN.MINION_SKILL_TOOLTIP
 msgctxt "STRINGS.UI.JOBSSCREEN.MINION_SKILL_TOOLTIP"
@@ -6262,9 +6138,6 @@ msgid "Very Low"
 msgstr "最低"
 
 #. STRINGS.UI.JOBSSCREEN.PRIORITY_CLASS.BASIC
-#, fuzzy
-#| msgctxt "STRINGS.BUILDING.STATUSITEMS.NORMAL.NAME"
-#| msgid "Normal"
 msgctxt "STRINGS.UI.JOBSSCREEN.PRIORITY_CLASS.BASIC"
 msgid "Normal"
 msgstr "通常"
@@ -6272,36 +6145,27 @@ msgstr "通常"
 #. STRINGS.UI.JOBSSCREEN.PRIORITY_CLASS.COMPULSORY
 msgctxt "STRINGS.UI.JOBSSCREEN.PRIORITY_CLASS.COMPULSORY"
 msgid "Compulsory"
-msgstr ""
+msgstr "強制"
 
 #. STRINGS.UI.JOBSSCREEN.PRIORITY_CLASS.EMERGENCY
-#, fuzzy
-#| msgctxt "STRINGS.CREATURES.STATUSITEMS.EMERGING.NAME"
-#| msgid "Emerging"
 msgctxt "STRINGS.UI.JOBSSCREEN.PRIORITY_CLASS.EMERGENCY"
 msgid "Emergency"
-msgstr "浮上"
+msgstr "緊急"
 
 #. STRINGS.UI.JOBSSCREEN.PRIORITY_CLASS.HIGH
 msgctxt "STRINGS.UI.JOBSSCREEN.PRIORITY_CLASS.HIGH"
 msgid "Urgent"
-msgstr ""
+msgstr "急ぎ"
 
 #. STRINGS.UI.JOBSSCREEN.PRIORITY_CLASS.IDLE
-#, fuzzy
-#| msgctxt "STRINGS.CREATURES.STATUSITEMS.IDLE.NAME"
-#| msgid "Idle"
 msgctxt "STRINGS.UI.JOBSSCREEN.PRIORITY_CLASS.IDLE"
 msgid "Idle"
-msgstr "有閑"
+msgstr "待機"
 
 #. STRINGS.UI.JOBSSCREEN.PRIORITY_CLASS.PERSONAL_NEEDS
-#, fuzzy
-#| msgctxt "STRINGS.DUPLICANTS.ATTRIBUTES.QUALITYOFLIFEEXPECTATION.DESC"
-#| msgid "Morale Need"
 msgctxt "STRINGS.UI.JOBSSCREEN.PRIORITY_CLASS.PERSONAL_NEEDS"
 msgid "Personal Needs"
-msgstr "必要な士気"
+msgstr "個人的な需要"
 
 #. STRINGS.UI.JOBSSCREEN.RESET_SETTINGS
 msgctxt "STRINGS.UI.JOBSSCREEN.RESET_SETTINGS"
@@ -6468,13 +6332,10 @@ msgid "<link=\"BUILDCATEGORYBASE\">Base</link>"
 msgstr "<link=\"BUILDCATEGORYBASE\">基地</link>"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.BASE.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.BASE.TOOLTIP"
-#| msgid "Maintain your colony's infrastructure with these homebase basics."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.BASE.TOOLTIP"
 msgid ""
 "Maintain your colony's infrastructure with these homebase basics. {Hotkey}"
-msgstr "これらの基本的な土台でコロニーのインフラを支えましょう。"
+msgstr "これらの基本的な土台でコロニーのインフラを支えましょう。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.CONDUITSENSORS.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.CONDUITSENSORS.BUILDMENUTITLE"
@@ -6506,12 +6367,9 @@ msgstr ""
 "輸送"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.CONVEYANCE.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.CONVEYANCE.TOOLTIP"
-#| msgid "Move solids objects around."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.CONVEYANCE.TOOLTIP"
 msgid "Move solids objects around. {Hotkey}"
-msgstr "周辺の固体を移動します。"
+msgstr "周辺の固体を移動します。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.COOKING.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.COOKING.BUILDMENUTITLE"
@@ -6539,12 +6397,9 @@ msgid "Decor"
 msgstr "装飾"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.DECOR.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.DECOR.TOOLTIP"
-#| msgid "Spruce up your colony with some lovely interior decorating."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.DECOR.TOOLTIP"
 msgid "Spruce up your colony with some lovely interior decorating. {Hotkey}"
-msgstr "素敵なインテリアでコロニーを飾りましょう。"
+msgstr "素敵なインテリアでコロニーを飾りましょう。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.DOORS.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.DOORS.BUILDMENUTITLE"
@@ -6572,12 +6427,9 @@ msgid "Stations"
 msgstr "研究"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.EQUIPMENT.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.EQUIPMENT.TOOLTIP"
-#| msgid "Unlock new technologies through the power of science!"
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.EQUIPMENT.TOOLTIP"
 msgid "Unlock new technologies through the power of science! {Hotkey}"
-msgstr "科学の力で新しい技術を手に入れましょう！"
+msgstr "科学の力で新しい技術を手に入れましょう！{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.FARMING.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.FARMING.BUILDMENUTITLE"
@@ -6600,12 +6452,9 @@ msgid "<link=\"BUILDCATEGORYFOODANDAGRICULTURE\">Food</link>"
 msgstr "<link=\"BUILDCATEGORYFOODANDAGRICULTURE\">食糧</link>"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.FOODANDAGRICULTURE.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.FOODANDAGRICULTURE.TOOLTIP"
-#| msgid "Keep your Duplicants' spirits high and their bellies full."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.FOODANDAGRICULTURE.TOOLTIP"
 msgid "Keep your Duplicants' spirits high and their bellies full. {Hotkey}"
-msgstr "複製人間の心と胃袋を満たしましょう。"
+msgstr "複製人間の心と胃袋を満たしましょう。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.FURNITURE.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.FURNITURE.BUILDMENUTITLE"
@@ -6618,12 +6467,9 @@ msgid "Furniture"
 msgstr "家具"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.FURNITURE.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.FURNITURE.TOOLTIP"
-#| msgid "Amenities to keep your Duplicants happy, comfy and efficient."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.FURNITURE.TOOLTIP"
 msgid "Amenities to keep your Duplicants happy, comfy and efficient. {Hotkey}"
-msgstr "複製人間が幸せで快適に効率よく生活するためのアメニティです。"
+msgstr "複製人間が幸せで快適に効率よく生活するためのアメニティです。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.GENERATORS.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.GENERATORS.BUILDMENUTITLE"
@@ -6646,13 +6492,11 @@ msgid "<link=\"BUILDCATEGORYHEALTHANDHAPPINESS\">Accommodation</link>"
 msgstr "<link=\"BUILDCATEGORYHEALTHANDHAPPINESS\">宿泊</link>"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.HEALTHANDHAPPINESS.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.HEALTHANDHAPPINESS.TOOLTIP"
-#| msgid "Everything a Duplicant needs to stay happy, healthy, and fulfilled."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.HEALTHANDHAPPINESS.TOOLTIP"
 msgid ""
 "Everything a Duplicant needs to stay happy, healthy, and fulfilled. {Hotkey}"
-msgstr "複製人間が幸せで健康的な満たされた生活に必要なものが揃っています。"
+msgstr ""
+"複製人間が幸せで健康的な満たされた生活に必要なものが揃っています。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.HYGIENE.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.HYGIENE.BUILDMENUTITLE"
@@ -6675,15 +6519,11 @@ msgid "<link=\"BUILDCATEGORYINDUSTRIAL\">Industrials</link>"
 msgstr "<link=\"BUILDCATEGORYINDUSTRIAL\">工業</link>"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.INDUSTRIAL.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.INDUSTRIAL.TOOLTIP"
-#| msgid ""
-#| "Machinery for oxygen production, heat management, and material refinement."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.INDUSTRIAL.TOOLTIP"
 msgid ""
 "Machinery for oxygen production, heat management, and material refinement. "
 "{Hotkey}"
-msgstr "酸素生産、温度管理、素材精製のための機械です。"
+msgstr "酸素生産、温度管理、素材精製のための機械です。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.INFRASTRUCTURE.NAME
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.INFRASTRUCTURE.NAME"
@@ -6691,12 +6531,9 @@ msgid "<link=\"BUILDCATEGORYINFRASTRUCTURE\">Utilities</link>"
 msgstr "<link=\"BUILDCATEGORYINFRASTRUCTURE\">その他</link>"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.INFRASTRUCTURE.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.INFRASTRUCTURE.TOOLTIP"
-#| msgid "Power, plumbing, and ventilation can all be found here."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.INFRASTRUCTURE.TOOLTIP"
 msgid "Power, plumbing, and ventilation can all be found here. {Hotkey}"
-msgstr "電力、配管、換気類はここにあります。"
+msgstr "電力、配管、換気類はここにあります。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.LADDERS.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.LADDERS.BUILDMENUTITLE"
@@ -6776,12 +6613,9 @@ msgid "<link=\"BUILDCATEGORYLOGISTICS\">Logistics</link>"
 msgstr "<link=\"BUILDCATEGORYLOGISTICS\">物流</link>"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.LOGISTICS.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.LOGISTICS.TOOLTIP"
-#| msgid "Devices for base automation and material transport."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.LOGISTICS.TOOLTIP"
 msgid "Devices for base automation and material transport. {Hotkey}"
-msgstr "基地の自動化および素材の輸送のための装置です。"
+msgstr "基地の自動化および素材の輸送のための装置です。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.MEDICAL.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.MEDICAL.BUILDMENUTITLE"
@@ -6794,12 +6628,9 @@ msgid "Medical"
 msgstr "医療"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.MEDICAL.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.MEDICAL.TOOLTIP"
-#| msgid "A cure for everything but the common cold."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.MEDICAL.TOOLTIP"
 msgid "A cure for everything but the common cold. {Hotkey}"
-msgstr "風邪以外なら何でも治します。"
+msgstr "風邪以外なら何でも治します。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.OXYGEN.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.OXYGEN.BUILDMENUTITLE"
@@ -6812,12 +6643,9 @@ msgid "Oxygen"
 msgstr "酸素"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.OXYGEN.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.OXYGEN.TOOLTIP"
-#| msgid "Everything you need to keep your colony breathing."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.OXYGEN.TOOLTIP"
 msgid "Everything you need to keep your colony breathing. {Hotkey}"
-msgstr "コロニー内で呼吸するために必要なものが揃っています。"
+msgstr "コロニー内で呼吸するために必要なものが全て揃っています。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.PIPES.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.PIPES.BUILDMENUTITLE"
@@ -6845,12 +6673,9 @@ msgid "Plumbing"
 msgstr "配管"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.PLUMBINGSTRUCTURES.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.PLUMBINGSTRUCTURES.TOOLTIP"
-#| msgid "Get your water running and the sewage flowing."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.PLUMBINGSTRUCTURES.TOOLTIP"
 msgid "Get your water running and the sewage flowing. {Hotkey}"
-msgstr "上水下水の制御をします。"
+msgstr "上水下水の制御をします。 {Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.POWERCONTROL.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.POWERCONTROL.BUILDMENUTITLE"
@@ -6912,12 +6737,9 @@ msgid "Refinement"
 msgstr "精製"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.REFINING.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.REFINING.TOOLTIP"
-#| msgid "Use the resources you want, filter the ones you don't."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.REFINING.TOOLTIP"
 msgid "Use the resources you want, filter the ones you don't. {Hotkey}"
-msgstr "いらないものはろ過して、欲しいものだけ使いましょう。"
+msgstr "いらないものはろ過して、欲しいものだけ使いましょう。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.RESEARCH.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.RESEARCH.BUILDMENUTITLE"
@@ -6945,12 +6767,9 @@ msgid "Rocketry"
 msgstr "ロケット工学"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.ROCKETRY.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.BUILDCATEGORIES.ROCKETRY.TOOLTIP"
-#| msgid "Rocketry"
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.ROCKETRY.TOOLTIP"
 msgid "Rocketry {Hotkey}"
-msgstr "ロケット工学"
+msgstr "ロケット工学{Hotkey}"
 
 # 格納庫以外にも、農地タイルでこのアクションが使用できた
 #. STRINGS.UI.NEWBUILDCATEGORIES.STORAGE.BUILDMENUTITLE
@@ -7033,12 +6852,9 @@ msgid "Ventilation"
 msgstr "換気"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.VENTILATIONSTRUCTURES.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.VENTILATIONSTRUCTURES.TOOLTIP"
-#| msgid "Control the flow of gas in your base."
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.VENTILATIONSTRUCTURES.TOOLTIP"
 msgid "Control the flow of gas in your base. {Hotkey}"
-msgstr "基地における気体の流れを制御します。"
+msgstr "基地における気体の流れを制御します。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.WIRES.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.WIRES.BUILDMENUTITLE"
@@ -7219,7 +7035,7 @@ msgstr "悪質な装飾"
 #. STRINGS.UI.OVERLAYS.DECOR.MAXIMUM_DECOR
 msgctxt "STRINGS.UI.OVERLAYS.DECOR.MAXIMUM_DECOR"
 msgid "{0}{1} (Maximum Decor)"
-msgstr ""
+msgstr "{0}{1} (最大装飾値)"
 
 #. STRINGS.UI.OVERLAYS.DECOR.NAME
 msgctxt "STRINGS.UI.OVERLAYS.DECOR.NAME"
@@ -8582,20 +8398,14 @@ msgid "Hot"
 msgstr "高熱"
 
 #. STRINGS.UI.OVERLAYS.TILEMODE.BUTTON
-#, fuzzy
-#| msgctxt "STRINGS.UI.OVERLAYS.JOULES.BUTTON"
-#| msgid "Joules Overlay"
 msgctxt "STRINGS.UI.OVERLAYS.TILEMODE.BUTTON"
 msgid "Elements Overlay"
-msgstr "ジュール熱レイヤー"
+msgstr "元素レイヤー"
 
 #. STRINGS.UI.OVERLAYS.TILEMODE.NAME
-#, fuzzy
-#| msgctxt "STRINGS.UI.OVERLAYS.DISEASE.NAME"
-#| msgid "GERM OVERLAY"
 msgctxt "STRINGS.UI.OVERLAYS.TILEMODE.NAME"
 msgid "ELEMENTS OVERLAY"
-msgstr "病原菌レイヤー"
+msgstr "元素レイヤー"
 
 #. STRINGS.UI.OVERLAYSTITLE
 msgctxt "STRINGS.UI.OVERLAYSTITLE"
@@ -8659,6 +8469,10 @@ msgid ""
 "This priority will override all other priorities and set the colony on Red "
 "Alert until the errand is completed."
 msgstr ""
+"優先度 緊急\n"
+"------------------\n"
+"この優先度は他の全ての優先度を上書きして、作業が完了するまでコロニーを非常事"
+"態に設定します。"
 
 #. STRINGS.UI.PRIORITYSCREEN.HIGH
 msgctxt "STRINGS.UI.PRIORITYSCREEN.HIGH"
@@ -9631,25 +9445,18 @@ msgid "<b>Duplicants who have mastered this job:</b>{0}"
 msgstr "<b>この職業を習得した複製人間:</b>{0}"
 
 #. STRINGS.UI.SANDBOX_TOGGLE.TOOLTIP_LOCKED
-#, fuzzy
-#| msgctxt "STRINGS.UI.SANDBOX_TOGGLE.TOOLTIP_LOCKED"
-#| msgid ""
-#| "Sandbox mode must be unlocked in the options menu before it can be used."
 msgctxt "STRINGS.UI.SANDBOX_TOGGLE.TOOLTIP_LOCKED"
 msgid ""
 "Sandbox mode must be unlocked in the options menu before it can be used. "
 "{Hotkey}"
 msgstr ""
 "サンドボックスモードを使う前に、オプションメニューからサンドボックスモードを"
-"有効にしてください。"
+"有効にしてください。{Hotkey}"
 
 #. STRINGS.UI.SANDBOX_TOGGLE.TOOLTIP_UNLOCKED
-#, fuzzy
-#| msgctxt "STRINGS.UI.SANDBOX_TOGGLE.TOOLTIP_UNLOCKED"
-#| msgid "Toggle Sandbox mode"
 msgctxt "STRINGS.UI.SANDBOX_TOGGLE.TOOLTIP_UNLOCKED"
 msgid "Toggle Sandbox mode {Hotkey}"
-msgstr "サンドボックスモードの切り替え"
+msgstr "サンドボックスモードの切り替え{Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.CLEARFLOOR.DELETED
 msgctxt "STRINGS.UI.SANDBOXTOOLS.CLEARFLOOR.DELETED"
@@ -9738,12 +9545,9 @@ msgid "Brush"
 msgstr "ブラシ"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.BRUSH.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.BRUSH.TOOLTIP"
-#| msgid "Paint elements into the world simulation"
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.BRUSH.TOOLTIP"
 msgid "Paint elements into the world simulation {Hotkey}"
-msgstr "シミュレーションへ元素を塗りたくります"
+msgstr "シミュレーションへ元素を塗りたくります{Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.BRUSH_NOISE.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.BRUSH_NOISE.NAME"
@@ -9771,12 +9575,9 @@ msgid "Clear Debris"
 msgstr "がれき掃除"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.CLEAR_FLOOR.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.CLEAR_FLOOR.TOOLTIP"
-#| msgid "Delete loose items cluttering the floor"
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.CLEAR_FLOOR.TOOLTIP"
 msgid "Delete loose items cluttering the floor {Hotkey}"
-msgstr "床に散らばったアイテムを削除します"
+msgstr "床に散らばったアイテムを削除します{Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.DESTROY.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.DESTROY.NAME"
@@ -9784,12 +9585,9 @@ msgid "Destroy"
 msgstr "破壊"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.DESTROY.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.DESTROY.TOOLTIP"
-#| msgid "Delete everything in the selected cell(s)"
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.DESTROY.TOOLTIP"
 msgid "Delete everything in the selected cell(s) {Hotkey}"
-msgstr "選択したセル内の全てを破壊します"
+msgstr "選択したセル内の全てを破壊します{Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.DISEASE_COUNT.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.DISEASE_COUNT.NAME"
@@ -9807,12 +9605,9 @@ msgid "Fill"
 msgstr "塗りつぶし"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.FLOOD.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.FLOOD.TOOLTIP"
-#| msgid "Fill a section of the simulation with the chosen element"
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.FLOOD.TOOLTIP"
 msgid "Fill a section of the simulation with the chosen element {Hotkey}"
-msgstr "選択した元素で矩形を塗りつぶします"
+msgstr "選択した元素で矩形を塗りつぶします{Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.FOW.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.FOW.NAME"
@@ -9820,12 +9615,9 @@ msgid "Reveal"
 msgstr "マップ開示"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.FOW.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.FOW.TOOLTIP"
-#| msgid "Dispel the Fog of War shrouding the map"
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.FOW.TOOLTIP"
 msgid "Dispel the Fog of War shrouding the map {Hotkey}"
-msgstr "マップ上の暗闇を消去します"
+msgstr "マップ上のFoW(戦場の霧)を消去します{Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.HEATGUN.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.HEATGUN.NAME"
@@ -9833,12 +9625,9 @@ msgid "Heat Gun"
 msgstr "ヒートガン"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.HEATGUN.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.HEATGUN.TOOLTIP"
-#| msgid "Inject thermal energy into the simulation"
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.HEATGUN.TOOLTIP"
 msgid "Inject thermal energy into the simulation {Hotkey}"
-msgstr "熱エネルギーを注入します"
+msgstr "熱エネルギーを注入します{Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.INSTANT_BUILD.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.INSTANT_BUILD.NAME"
@@ -9866,12 +9655,9 @@ msgid "Sample"
 msgstr "サンプル"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.SAMPLE.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SAMPLE.TOOLTIP"
-#| msgid "Copy the settings from a cell to use with brush tools"
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SAMPLE.TOOLTIP"
 msgid "Copy the settings from a cell to use with brush tools {Hotkey}"
-msgstr "ブラシツールで使うために、セルの設定をコピーします"
+msgstr "ブラシツールで使うために、セルの設定をコピーします{Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPAWN_ENTITY.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPAWN_ENTITY.NAME"
@@ -9884,12 +9670,9 @@ msgid "Spawner"
 msgstr "生成機"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPAWNER.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPAWNER.TOOLTIP"
-#| msgid "Spawn critters, food, equipment, and other entities"
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPAWNER.TOOLTIP"
 msgid "Spawn critters, food, equipment, and other entities {Hotkey}"
-msgstr "食糧や生物、装備などのモノを生成します"
+msgstr "食糧や生物、装備などのモノを生成します{Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPRINKLE.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPRINKLE.NAME"
@@ -9897,12 +9680,9 @@ msgid "Sprinkle"
 msgstr "ばら撒き"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPRINKLE.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPRINKLE.TOOLTIP"
-#| msgid "Paint elements into the simulation using noise"
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPRINKLE.TOOLTIP"
 msgid "Paint elements into the simulation using noise {Hotkey}"
-msgstr "元素をスプレーします"
+msgstr "元素をスプレーします{Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.TEMPERATURE.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.TEMPERATURE.NAME"
@@ -10264,71 +10044,44 @@ msgstr "設定"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.AMELIASWATCH.DESCRIPTION"
 msgid ""
 "It was discovered in a package labeled \"To be entrusted to Dr. Walker\"."
-msgstr ""
+msgstr "それは\"Dr.ウォーカーへ委託\"とラベルが貼られた箱の中から見つかった。"
 
 #. STRINGS.UI.SPACEARTIFACTS.AMELIASWATCH.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.AMELIASWATCH.NAME"
 msgid "Wrist Watch"
-msgstr ""
+msgstr "腕時計"
 
 #. STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER_NONE
-#, fuzzy
-#| msgctxt "STRINGS.UI.UISIDESCREENS.COMETDETECTORSIDESCREEN.NOTHING"
-#| msgid "Nothing"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER_NONE"
 msgid "Nothing"
 msgstr "無し"
 
 #. STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER0
-#, fuzzy
-#| msgctxt ""
-#| "STRINGS.UI.ROLES_SCREEN.EXPECTATIONS.QUALITYOFLIFE.TIER0.DESCRIPTION"
-#| msgid "Tier 0"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER0"
 msgid "Tier 0"
 msgstr "Tier 0"
 
 #. STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER1
-#, fuzzy
-#| msgctxt ""
-#| "STRINGS.UI.ROLES_SCREEN.EXPECTATIONS.QUALITYOFLIFE.TIER1.DESCRIPTION"
-#| msgid "Tier 1"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER1"
 msgid "Tier 1"
 msgstr "Tier 1"
 
 #. STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER2
-#, fuzzy
-#| msgctxt ""
-#| "STRINGS.UI.ROLES_SCREEN.EXPECTATIONS.QUALITYOFLIFE.TIER2.DESCRIPTION"
-#| msgid "Tier 2"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER2"
 msgid "Tier 2"
 msgstr "Tier 2"
 
 #. STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER3
-#, fuzzy
-#| msgctxt ""
-#| "STRINGS.UI.ROLES_SCREEN.EXPECTATIONS.QUALITYOFLIFE.TIER3.DESCRIPTION"
-#| msgid "Tier 3"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER3"
 msgid "Tier 3"
 msgstr "Tier 3"
 
 #. STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER4
-#, fuzzy
-#| msgctxt ""
-#| "STRINGS.UI.ROLES_SCREEN.EXPECTATIONS.QUALITYOFLIFE.TIER4.DESCRIPTION"
-#| msgid "Tier 4"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER4"
 msgid "Tier 4"
 msgstr "Tier 4"
 
 #. STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER5
-#, fuzzy
-#| msgctxt ""
-#| "STRINGS.UI.ROLES_SCREEN.EXPECTATIONS.QUALITYOFLIFE.TIER5.DESCRIPTION"
-#| msgid "Tier 5"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ARTIFACTTIERS.TIER5"
 msgid "Tier 5"
 msgstr "Tier 5"
@@ -10339,11 +10092,13 @@ msgid ""
 "A thriving colony of tiny, microscopic organisms is responsible for giving "
 "it its bluish glow."
 msgstr ""
+"あるちっぽけな、顕微鏡レベルの生物が繁栄するコロニーには、その青みを帯びた輝"
+"きを与える責任がある。"
 
 #. STRINGS.UI.SPACEARTIFACTS.BIOLUMROCK.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.BIOLUMROCK.NAME"
 msgid "Bioluminescent Rock"
-msgstr ""
+msgstr "生物発光岩"
 
 #. STRINGS.UI.SPACEARTIFACTS.BLENDER.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.BLENDER.DESCRIPTION"
@@ -10351,37 +10106,32 @@ msgid ""
 "Equipment used to conduct experiments answering the age-old question, "
 "\"Could that blend\"?"
 msgstr ""
+"古くからある質問、\"混ぜてもいいか？\"に答えるための実験を行うための機器。"
 
 #. STRINGS.UI.SPACEARTIFACTS.BLENDER.NAME
-#, fuzzy
-#| msgctxt "STRINGS.DUPLICANTS.GENDERTITLE"
-#| msgid "Gender: "
 msgctxt "STRINGS.UI.SPACEARTIFACTS.BLENDER.NAME"
 msgid "Blender"
-msgstr "性別: "
+msgstr "撹拌機"
 
 #. STRINGS.UI.SPACEARTIFACTS.BRICKPHONE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.BRICKPHONE.DESCRIPTION"
 msgid "It still works."
-msgstr ""
+msgstr "まだ動く。"
 
 #. STRINGS.UI.SPACEARTIFACTS.BRICKPHONE.NAME
-#, fuzzy
-#| msgctxt "STRINGS.CODEX.NOTETOJODI.TITLE"
-#| msgid "Strange Note"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.BRICKPHONE.NAME"
 msgid "Strange Brick"
-msgstr "奇妙なメモ"
+msgstr "奇妙なガラケー"
 
 #. STRINGS.UI.SPACEARTIFACTS.DNAMODEL.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.DNAMODEL.DESCRIPTION"
 msgid "An educational model of genetic information."
-msgstr ""
+msgstr "遺伝情報の教育モデル"
 
 #. STRINGS.UI.SPACEARTIFACTS.DNAMODEL.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.DNAMODEL.NAME"
 msgid "Double Helix Model"
-msgstr ""
+msgstr "二重らせんモデル"
 
 #. STRINGS.UI.SPACEARTIFACTS.EGGROCK.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.EGGROCK.DESCRIPTION"
@@ -10389,68 +10139,63 @@ msgid ""
 "It's unclear whether this is its naturally occurring shape, or if its "
 "appearance as been sculpted."
 msgstr ""
+"これが自然にそのような形になったのか、そのような形に彫刻されたのかは不明だ。"
 
 #. STRINGS.UI.SPACEARTIFACTS.EGGROCK.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.EGGROCK.NAME"
 msgid "Egg-Shaped Rock"
-msgstr ""
+msgstr "卵型の岩"
 
 #. STRINGS.UI.SPACEARTIFACTS.HATCHFOSSIL.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.HATCHFOSSIL.DESCRIPTION"
 msgid "The preserved bones of an early species of Hatch."
-msgstr ""
+msgstr "ハッチ初期種の保存された骨"
 
 #. STRINGS.UI.SPACEARTIFACTS.HATCHFOSSIL.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.HATCHFOSSIL.NAME"
 msgid "Pristine Fossil"
-msgstr ""
+msgstr "自然のままの化石"
 
 #. STRINGS.UI.SPACEARTIFACTS.MAGMALAMP.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MAGMALAMP.DESCRIPTION"
 msgid "The sequel to \"Lava Lamp\"."
-msgstr ""
+msgstr "\"溶岩ランプ\"の後編。"
 
 #. STRINGS.UI.SPACEARTIFACTS.MAGMALAMP.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MAGMALAMP.NAME"
 msgid "Magma Lamp"
-msgstr ""
+msgstr "マグマランプ"
 
 # sweat(名詞:汗、動詞:酷使する)
 #. STRINGS.UI.SPACEARTIFACTS.MODERNART.DESCRIPTION
-#, fuzzy
-#| msgctxt "STRINGS.EQUIPMENT.PREFABS.COOL_VEST.DESC"
-#| msgid "Don't sweat it!"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MODERNART.DESCRIPTION"
 msgid "I don't get it."
-msgstr "酷使しないで！"
+msgstr "意味が分からない。"
 
 #. STRINGS.UI.SPACEARTIFACTS.MODERNART.NAME
-#, fuzzy
-#| msgctxt "STRINGS.MISC.STATUSITEMS.HEALTHSTATUS.INJURED.NAME"
-#| msgid "Moderate"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MODERNART.NAME"
 msgid "Modern Art"
-msgstr "中程度"
+msgstr "近代美術"
 
 #. STRINGS.UI.SPACEARTIFACTS.MOLDAVITE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MOLDAVITE.DESCRIPTION"
 msgid "A unique green stone formed from the impact of a meteorite."
-msgstr ""
+msgstr "隕石の衝撃で形成されたユニークな緑色の石。"
 
 #. STRINGS.UI.SPACEARTIFACTS.MOLDAVITE.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MOLDAVITE.NAME"
 msgid "Moldavite"
-msgstr ""
+msgstr "モルダバイト"
 
 #. STRINGS.UI.SPACEARTIFACTS.MOONMOONMOON.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MOONMOONMOON.DESCRIPTION"
 msgid "A moon's moon's moon. It's very small."
-msgstr ""
+msgstr "月の月の月。とても小さい。"
 
 #. STRINGS.UI.SPACEARTIFACTS.MOONMOONMOON.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MOONMOONMOON.NAME"
 msgid "Moonmoonmoon"
-msgstr ""
+msgstr "ムーンムーンムーン"
 
 #. STRINGS.UI.SPACEARTIFACTS.OBELISK.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.OBELISK.DESCRIPTION"
@@ -10459,59 +10204,56 @@ msgid ""
 "\n"
 "Its function is unclear."
 msgstr ""
+"長方形の石片。\n"
+"\n"
+"その機能は不明だ。"
 
 #. STRINGS.UI.SPACEARTIFACTS.OBELISK.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.OBELISK.NAME"
 msgid "Small Obelisk"
-msgstr ""
+msgstr "小さなオベリスク"
 
 #. STRINGS.UI.SPACEARTIFACTS.OFFICEMUG.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.OFFICEMUG.DESCRIPTION"
 msgid ""
 "An intermediary place to store espresso before you move it to your mouth."
-msgstr ""
+msgstr "エスプレッソを口に運ぶ前に保管する中間の場所。"
 
 #. STRINGS.UI.SPACEARTIFACTS.OFFICEMUG.NAME
-#, fuzzy
-#| msgctxt "STRINGS.BUILDINGS.PREFABS.PROPFACILITYTALLPLANT.NAME"
-#| msgid "Office Plant"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.OFFICEMUG.NAME"
 msgid "Office Mug"
-msgstr "観葉植物"
+msgstr "事務所のマグカップ"
 
 #. STRINGS.UI.SPACEARTIFACTS.OKAYXRAY.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.OKAYXRAY.DESCRIPTION"
 msgid "Ew, weird. It has five fingers!"
-msgstr ""
+msgstr "えっ、変だ。指が5本ある！"
 
 #. STRINGS.UI.SPACEARTIFACTS.OKAYXRAY.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.OKAYXRAY.NAME"
 msgid "Old X-Ray"
-msgstr ""
+msgstr "古いレントゲン"
 
 #. STRINGS.UI.SPACEARTIFACTS.PERCOLATOR.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.PERCOLATOR.DESCRIPTION"
 msgid "Don't drink from it! There was a pacu... IN the percolator!"
-msgstr ""
+msgstr "それから飲んでは駄目だ！そのコーヒー沸かしの中にパクーが居たんだ…"
 
 # Prospect + lator
 #. STRINGS.UI.SPACEARTIFACTS.PERCOLATOR.NAME
-#, fuzzy
-#| msgctxt "STRINGS.EQUIPMENT.PREFABS.BORING_MACHINE.NAME"
-#| msgid "Prospectolator"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.PERCOLATOR.NAME"
 msgid "Percolator"
-msgstr "展望観測機"
+msgstr "濾過装置付きコーヒー沸かし"
 
 #. STRINGS.UI.SPACEARTIFACTS.PLASMALAMP.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.PLASMALAMP.DESCRIPTION"
 msgid "No space colony is complete without one."
-msgstr ""
+msgstr "それなしではスペースコロニーは完成しない。"
 
 #. STRINGS.UI.SPACEARTIFACTS.PLASMALAMP.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.PLASMALAMP.NAME"
 msgid "Plasma Lamp"
-msgstr ""
+msgstr "プラズマランプ"
 
 #. STRINGS.UI.SPACEARTIFACTS.RAINBOWEGGROCK.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.RAINBOWEGGROCK.DESCRIPTION"
@@ -10521,137 +10263,129 @@ msgid ""
 "\n"
 "This one is rainbow coloured."
 msgstr ""
+"これが自然にそのような形になったのか、そのような形に彫刻されたのかは不明"
+"だ。\n"
+"\n"
+"これは虹色だ。"
 
 #. STRINGS.UI.SPACEARTIFACTS.RAINBOWEGGROCK.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.RAINBOWEGGROCK.NAME"
 msgid "Egg-Shaped Rock"
-msgstr ""
+msgstr "卵型の岩"
 
 #. STRINGS.UI.SPACEARTIFACTS.ROBOTARM.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ROBOTARM.DESCRIPTION"
 msgid "It's not functional. Just cool."
-msgstr ""
+msgstr "機能的では無い。かっこいいだけ。"
 
 #. STRINGS.UI.SPACEARTIFACTS.ROBOTARM.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ROBOTARM.NAME"
 msgid "Robot Arm"
-msgstr ""
+msgstr "ロボットアーム"
 
 #. STRINGS.UI.SPACEARTIFACTS.ROCKTORNADO.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ROCKTORNADO.DESCRIPTION"
 msgid "It's unclear how it formed, although I'm glad it did."
-msgstr ""
+msgstr "どのように形成されたかは不明だ、でもそうなったのが嬉しい。"
 
 #. STRINGS.UI.SPACEARTIFACTS.ROCKTORNADO.NAME
-#, fuzzy
-#| msgctxt "STRINGS.UI.STARMAP.LAND_ROCKET"
-#| msgid "Land Rocket"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ROCKTORNADO.NAME"
 msgid "Tornado Rock"
-msgstr "ロケット着陸"
+msgstr "トルネードロック"
 
 #. STRINGS.UI.SPACEARTIFACTS.RUBIKSCUBE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.RUBIKSCUBE.DESCRIPTION"
 msgid "This mystery of the universe has already been solved."
-msgstr ""
+msgstr "この宇宙の謎は既に解決した。"
 
 #. STRINGS.UI.SPACEARTIFACTS.RUBIKSCUBE.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.RUBIKSCUBE.NAME"
 msgid "Rubik's Cube"
-msgstr ""
+msgstr "ルービックキューブ"
 
 #. STRINGS.UI.SPACEARTIFACTS.SANDSTONE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SANDSTONE.DESCRIPTION"
 msgid "A beautiful rock composed of multiple layers of sediment."
-msgstr ""
+msgstr "堆積物が幾重にも重なってできた美しい岩。"
 
 #. STRINGS.UI.SPACEARTIFACTS.SANDSTONE.NAME
-#, fuzzy
-#| msgctxt "STRINGS.INPUT_BINDINGS.SANDBOX.NAME"
-#| msgid "Sandbox"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SANDSTONE.NAME"
 msgid "Sandstone"
-msgstr "サンドボックス"
+msgstr "砂岩"
 
 #. STRINGS.UI.SPACEARTIFACTS.SAXOPHONE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SAXOPHONE.DESCRIPTION"
 msgid "The name \"Pesquet\" is barely legible on the inside."
-msgstr ""
+msgstr "\"ペスケ\"という名前は、内側ではほとんど判読出来ない。"
 
 #. STRINGS.UI.SPACEARTIFACTS.SAXOPHONE.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SAXOPHONE.NAME"
 msgid "Mangled Saxophone"
-msgstr ""
+msgstr "ずたずたのサクソフォン"
 
 #. STRINGS.UI.SPACEARTIFACTS.SHIELDGENERATOR.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SHIELDGENERATOR.DESCRIPTION"
 msgid ""
 "A mechanical prototype capable of producing a small section of shielding."
-msgstr ""
+msgstr "シールドの小さな部分を作り出すことが出来るメカニカルな試作品"
 
 #. STRINGS.UI.SPACEARTIFACTS.SHIELDGENERATOR.NAME
-#, fuzzy
-#| msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.GENERATORS.BUILDMENUTITLE"
-#| msgid "Generators"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SHIELDGENERATOR.NAME"
 msgid "Shield Generator"
-msgstr "発電機"
+msgstr "シールド生成器"
 
 #. STRINGS.UI.SPACEARTIFACTS.SINK.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SINK.DESCRIPTION"
 msgid "No collection is complete without it."
-msgstr ""
+msgstr "それなしではコレクションは完成しない。"
 
 #. STRINGS.UI.SPACEARTIFACTS.SINK.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SINK.NAME"
 msgid "Sink"
-msgstr ""
+msgstr "シンク"
 
 #. STRINGS.UI.SPACEARTIFACTS.SOLARSYSTEM.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SOLARSYSTEM.DESCRIPTION"
 msgid ""
 "A marvel of the cosmos, inside this display is an entirely self-contained "
 "solar system."
-msgstr ""
+msgstr "このディスプレイの中の宇宙の驚異は、完全な自己完結型の太陽光発電だ。"
 
 #. STRINGS.UI.SPACEARTIFACTS.SOLARSYSTEM.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SOLARSYSTEM.NAME"
 msgid "Self-Contained System"
-msgstr ""
+msgstr "自己完結型のシステム"
 
 #. STRINGS.UI.SPACEARTIFACTS.STETHOSCOPE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.STETHOSCOPE.DESCRIPTION"
 msgid "Listens to Duplicant heartbeats, or gurgley tummies."
-msgstr ""
+msgstr "複製人間の心拍や、ゴロゴロ鳴るお腹を聴く。"
 
 #. STRINGS.UI.SPACEARTIFACTS.STETHOSCOPE.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.STETHOSCOPE.NAME"
 msgid "Stethoscope"
-msgstr ""
+msgstr "聴診器"
 
 #. STRINGS.UI.SPACEARTIFACTS.TEAPOT.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.TEAPOT.DESCRIPTION"
 msgid ""
 "A teapot from the depths of space, coated in a thick layer of Neutronium."
-msgstr ""
+msgstr "厚いニュートロニウムの層で覆われた、宇宙の深層のティーポット。"
 
 #. STRINGS.UI.SPACEARTIFACTS.TEAPOT.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.TEAPOT.NAME"
 msgid "Encrusted Teapot"
-msgstr ""
+msgstr "覆われたティーポット"
 
 #. STRINGS.UI.SPACEARTIFACTS.VHS.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.VHS.DESCRIPTION"
 msgid "Be kind when you handle it. It's very fragile."
-msgstr ""
+msgstr "それを取り扱う時は優しくしなさい。とても壊れやすい。"
 
 #. STRINGS.UI.SPACEARTIFACTS.VHS.NAME
-#, fuzzy
-#| msgctxt "STRINGS.UI.RESEARCHSCREEN_FILTER"
-#| msgid "Search Tech"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.VHS.NAME"
 msgid "Archaic Tech"
-msgstr "技術研究"
+msgstr "古代の技術"
 
 #. STRINGS.UI.SPACEDESTINATIONS.ASTEROIDS.CARBONACEOUSASTEROID.DESCRIPTION
 msgctxt ""
@@ -11118,7 +10852,7 @@ msgstr "分析"
 #. STRINGS.UI.STARMAP.LISTTITLES.ARTIFACTS
 msgctxt "STRINGS.UI.STARMAP.LISTTITLES.ARTIFACTS"
 msgid "Artifacts"
-msgstr ""
+msgstr "アーティファクト"
 
 #. STRINGS.UI.STARMAP.LISTTITLES.DISTANCE
 msgctxt "STRINGS.UI.STARMAP.LISTTITLES.DISTANCE"
@@ -11686,17 +11420,11 @@ msgid "Empty Pipe tool"
 msgstr "配管掃除ツール"
 
 #. STRINGS.UI.TOOLS.EMPTY_PIPE.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLS.EMPTY_PIPE.TOOLTIP"
-#| msgid "Extract pipe contents"
 msgctxt "STRINGS.UI.TOOLS.EMPTY_PIPE.TOOLTIP"
 msgid "Extract pipe contents {Hotkey}"
-msgstr "配管の中身を抽出する"
+msgstr "配管の中身を抽出します {Hotkey}"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.AGRICULTURE
-#, fuzzy
-#| msgctxt "STRINGS.MISC.TAGS.AGRICULTURE"
-#| msgid "Agriculture"
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.AGRICULTURE"
 msgid "Agriculture"
 msgstr "農業"
@@ -11717,20 +11445,14 @@ msgid "Background Buildings"
 msgstr "壁裏設備"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.BREATHABLE
-#, fuzzy
-#| msgctxt "STRINGS.MISC.TAGS.BREATHABLE"
-#| msgid "Breathable Gas"
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.BREATHABLE"
 msgid "Breathable Gas"
 msgstr "呼吸可能な気体"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.BUILDABLE
-#, fuzzy
-#| msgctxt "STRINGS.MISC.TAGS.BUILDABLERAW"
-#| msgid "Raw Mineral"
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.BUILDABLE"
 msgid "Mineral"
-msgstr "無機物原石"
+msgstr "鉱石"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.BUILDINGS
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.BUILDINGS"
@@ -11743,9 +11465,6 @@ msgid "Sweep & Mop Orders"
 msgstr "掃除&モップ指示"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.CONSUMABLEORE
-#, fuzzy
-#| msgctxt "STRINGS.MISC.TAGS.CONSUMABLEORE"
-#| msgid "Consumable Ore"
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.CONSUMABLEORE"
 msgid "Consumable Ore"
 msgstr "消費用鉱石"
@@ -11761,25 +11480,16 @@ msgid "Disable Harvest"
 msgstr "収穫を無効化"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.FARMABLE
-#, fuzzy
-#| msgctxt "STRINGS.MISC.TAGS.FARMABLE"
-#| msgid "Cultivable Soil"
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.FARMABLE"
 msgid "Cultivable Soil"
 msgstr "耕作土"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.FILTER
-#, fuzzy
-#| msgctxt "STRINGS.MISC.TAGS.FILTER"
-#| msgid "Filtration Medium"
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.FILTER"
 msgid "Filtration Medium"
 msgstr "ろ過媒体"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.GAS
-#, fuzzy
-#| msgctxt "STRINGS.ELEMENTS.STATE.GAS"
-#| msgid "Gas"
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.GAS"
 msgid "Gas"
 msgstr "気体"
@@ -11795,9 +11505,6 @@ msgid "Enable Harvest"
 msgstr "収穫を有効化"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.LIQUID
-#, fuzzy
-#| msgctxt "STRINGS.ELEMENTS.STATE.LIQUID"
-#| msgid "Liquid"
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.LIQUID"
 msgid "Liquid"
 msgstr "液体"
@@ -11808,9 +11515,6 @@ msgid "Liquid Pipes"
 msgstr "液体用パイプ"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.LIQUIFIABLE
-#, fuzzy
-#| msgctxt "STRINGS.MISC.TAGS.LIQUIFIABLE"
-#| msgid "Liquefiable"
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.LIQUIFIABLE"
 msgid "Liquefiable"
 msgstr "液化可能"
@@ -11821,17 +11525,11 @@ msgid "Automation"
 msgstr "自動化"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.METAL
-#, fuzzy
-#| msgctxt "STRINGS.MISC.TAGS.METAL"
-#| msgid "Metal Ore"
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.METAL"
 msgid "Metal"
-msgstr "金属鉱石"
+msgstr "金属"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.ORGANICS
-#, fuzzy
-#| msgctxt "STRINGS.MISC.TAGS.ORGANICS"
-#| msgid "Organic"
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.ORGANICS"
 msgid "Organic"
 msgstr "有機物"
@@ -11847,9 +11545,6 @@ msgid "Tiles"
 msgstr "タイル"
 
 #. STRINGS.UI.TOOLS.FILTERLAYERS.UNBREATHABLE
-#, fuzzy
-#| msgctxt "STRINGS.MISC.TAGS.UNBREATHABLE"
-#| msgid "Unbreathable Gas"
 msgctxt "STRINGS.UI.TOOLS.FILTERLAYERS.UNBREATHABLE"
 msgid "Unbreathable Gas"
 msgstr "呼吸不可能な気体"
@@ -12058,12 +11753,9 @@ msgstr ""
 "警報はコロニーで現在起こっていることについて重要な情報を知らせてくれます"
 
 #. STRINGS.UI.TOOLTIPS.ATTACKBUTTON
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.ATTACKBUTTON"
-#| msgid "Attack poor, wild critters"
 msgctxt "STRINGS.UI.TOOLTIPS.ATTACKBUTTON"
 msgid "Attack poor, wild critters {Hotkey}"
-msgstr "可哀そうな野生動物を攻撃します"
+msgstr "可哀そうな野生動物を攻撃します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.BASE_VALUE
 msgctxt "STRINGS.UI.TOOLTIPS.BASE_VALUE"
@@ -12071,44 +11763,29 @@ msgid "Base Value"
 msgstr "基本値"
 
 #. STRINGS.UI.TOOLTIPS.CANCELBUTTON
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.CANCELBUTTON"
-#| msgid "Cancel errands"
 msgctxt "STRINGS.UI.TOOLTIPS.CANCELBUTTON"
 msgid "Cancel errands {Hotkey}"
-msgstr "作業をやめる"
+msgstr "作業をキャンセルします{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.CANCELDECONSTRUCTIONBUTTON
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.CANCELDECONSTRUCTIONBUTTON"
-#| msgid "Cancel queued orders or deconstruct existing buildings"
 msgctxt "STRINGS.UI.TOOLTIPS.CANCELDECONSTRUCTIONBUTTON"
 msgid "Cancel queued orders or deconstruct existing buildings {Hotkey}"
-msgstr "指示をキャンセルまたは既存の設備を解体します"
+msgstr "指示をキャンセルまたは既存の設備を解体します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.CAPTUREBUTTON
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.CAPTUREBUTTON"
-#| msgid "Capture critters"
 msgctxt "STRINGS.UI.TOOLTIPS.CAPTUREBUTTON"
 msgid "Capture critters {Hotkey}"
-msgstr "動物を捕獲します"
+msgstr "動物を捕獲します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.CLEANUPMAINBUTTON
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.CLEANUPMAINBUTTON"
-#| msgid "Mop and sweep messy floors"
 msgctxt "STRINGS.UI.TOOLTIPS.CLEANUPMAINBUTTON"
 msgid "Mop and sweep messy floors {Hotkey}"
-msgstr "汚れた床を掃除&モップ掛けします"
+msgstr "汚れた床を掃除&モップ掛けします{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.CLEARBUTTON
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.CLEARBUTTON"
-#| msgid "Move debris into storage"
 msgctxt "STRINGS.UI.TOOLTIPS.CLEARBUTTON"
 msgid "Move debris into storage {Hotkey}"
-msgstr "がれきを格納庫に移動します"
+msgstr "がれきを格納庫に移動します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.CLOSETOOLTIP
 msgctxt "STRINGS.UI.TOOLTIPS.CLOSETOOLTIP"
@@ -12116,60 +11793,39 @@ msgid "Close"
 msgstr "閉じる"
 
 #. STRINGS.UI.TOOLTIPS.CONVEYOR_OVERLAY_STRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.CONVEYOR_OVERLAY_STRING"
-#| msgid "Displays conveyor transport components"
 msgctxt "STRINGS.UI.TOOLTIPS.CONVEYOR_OVERLAY_STRING"
 msgid "Displays conveyor transport components {Hotkey}"
-msgstr "コンベアの配送状況を表示します"
+msgstr "コンベアの配送部品を表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.CROPS_OVERLAY_STRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.CROPS_OVERLAY_STRING"
-#| msgid "Displays plant growth progress"
 msgctxt "STRINGS.UI.TOOLTIPS.CROPS_OVERLAY_STRING"
 msgid "Displays plant growth progress {Hotkey}"
-msgstr "植物の生育状況を表示します"
+msgstr "植物の生育状況を表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.DECONSTRUCTBUTTON
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.DECONSTRUCTBUTTON"
-#| msgid "Demolish buildings"
 msgctxt "STRINGS.UI.TOOLTIPS.DECONSTRUCTBUTTON"
 msgid "Demolish buildings {Hotkey}"
-msgstr "設備を破壊します"
+msgstr "設備を破壊します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.DECOROVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.DECOROVERLAYSTRING"
-#| msgid "Displays areas with Morale-boosting decor values"
 msgctxt "STRINGS.UI.TOOLTIPS.DECOROVERLAYSTRING"
 msgid "Displays areas with Morale-boosting decor values {Hotkey}"
-msgstr "士気を上昇させる装飾値の範囲を表示します"
+msgstr "士気を上昇させる装飾値の範囲を表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.DIGBUTTON
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.DIGBUTTON"
-#| msgid "Set dig errands"
 msgctxt "STRINGS.UI.TOOLTIPS.DIGBUTTON"
 msgid "Set dig errands {Hotkey}"
-msgstr "採掘指示をします"
+msgstr "採掘作業を指示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.DISEASEOVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.DISEASEOVERLAYSTRING"
-#| msgid "Displays areas of disease risk"
 msgctxt "STRINGS.UI.TOOLTIPS.DISEASEOVERLAYSTRING"
 msgid "Displays areas of disease risk {Hotkey}"
-msgstr "病気リスクのあるエリアを表示します"
+msgstr "病気リスクのあるエリアを表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.DISINFECTBUTTON
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.DISINFECTBUTTON"
-#| msgid "Disinfect buildings"
 msgctxt "STRINGS.UI.TOOLTIPS.DISINFECTBUTTON"
 msgid "Disinfect buildings {Hotkey}"
-msgstr "設備を消毒します"
+msgstr "設備を消毒します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.DISMISSMESSAGE
 msgctxt "STRINGS.UI.TOOLTIPS.DISMISSMESSAGE"
@@ -12197,28 +11853,19 @@ msgid "<link=\"POWER\">Power</link> Required"
 msgstr "<link=\"POWER\">電力</link>要求"
 
 #. STRINGS.UI.TOOLTIPS.GASVENTOVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.GASVENTOVERLAYSTRING"
-#| msgid "Displays gas pipe system components"
 msgctxt "STRINGS.UI.TOOLTIPS.GASVENTOVERLAYSTRING"
 msgid "Displays gas pipe system components {Hotkey}"
-msgstr "気体用パイプの配管を表示します"
+msgstr "気体用パイプの配管を表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.HARVESTBUTTON
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.HARVESTBUTTON"
-#| msgid "Harvest plants"
 msgctxt "STRINGS.UI.TOOLTIPS.HARVESTBUTTON"
 msgid "Harvest plants {Hotkey}"
-msgstr "植物を収穫します"
+msgstr "植物を収穫します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.HEATFLOWOVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.HEATFLOWOVERLAYSTRING"
-#| msgid "Displays comfortable temperatures for Duplicants"
 msgctxt "STRINGS.UI.TOOLTIPS.HEATFLOWOVERLAYSTRING"
 msgid "Displays comfortable temperatures for Duplicants {Hotkey}"
-msgstr "複製人間が快適に感じる温度帯のエリアを表示します"
+msgstr "複製人間が快適に感じる温度帯のエリアを表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.HELP_BUILDLOCATION_ATTACHPOINT
 msgctxt "STRINGS.UI.TOOLTIPS.HELP_BUILDLOCATION_ATTACHPOINT"
@@ -12226,12 +11873,9 @@ msgid "Must be built overlapping an {0}"
 msgstr "{0}に重ねて建設する必要があります"
 
 #. STRINGS.UI.TOOLTIPS.HELP_BUILDLOCATION_BACK_WALL
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.HELP_BUILDLOCATION_PLATE_OBSTRUCTION"
-#| msgid "Obstructed by Tempshift Plate"
 msgctxt "STRINGS.UI.TOOLTIPS.HELP_BUILDLOCATION_BACK_WALL"
 msgid "Obstructed by back wall"
-msgstr "熱交換プレートによる妨げ"
+msgstr "裏壁で妨げられています"
 
 #. STRINGS.UI.TOOLTIPS.HELP_BUILDLOCATION_CEILING
 msgctxt "STRINGS.UI.TOOLTIPS.HELP_BUILDLOCATION_CEILING"
@@ -12259,9 +11903,6 @@ msgid "Gas ports cannot overlap"
 msgstr "気体ブリッジは重ねられません"
 
 #. STRINGS.UI.TOOLTIPS.HELP_BUILDLOCATION_HIGHWATT_NOT_IN_TILE
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.HELP_BUILDLOCATION_HIGHWATT_NOT_IN_TILE"
-#| msgid "Heavi-Watt power connectors cannot be built inside tile"
 msgctxt "STRINGS.UI.TOOLTIPS.HELP_BUILDLOCATION_HIGHWATT_NOT_IN_TILE"
 msgid "Heavi-Watt connectors cannot be built inside tile"
 msgstr "大容量電線はタイル内に敷設できません"
@@ -12388,52 +12029,34 @@ msgid "Displays the thermal energy in each cell"
 msgstr "各セルごとの熱エネルギーを表示します"
 
 #. STRINGS.UI.TOOLTIPS.LIGHTSOVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.LIGHTSOVERLAYSTRING"
-#| msgid "Displays the visibility radius of light sources"
 msgctxt "STRINGS.UI.TOOLTIPS.LIGHTSOVERLAYSTRING"
 msgid "Displays the visibility radius of light sources {Hotkey}"
-msgstr "光源の範囲を表示します"
+msgstr "光源の可視範囲を表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.LIQUIDVENTOVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.LIQUIDVENTOVERLAYSTRING"
-#| msgid "Displays liquid pipe system components"
 msgctxt "STRINGS.UI.TOOLTIPS.LIQUIDVENTOVERLAYSTRING"
 msgid "Displays liquid pipe system components {Hotkey}"
-msgstr "液体用パイプの配管を表示します"
+msgstr "液体用パイプの配管を表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.LOGICOVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.LOGICOVERLAYSTRING"
-#| msgid "Displays automation grid components"
 msgctxt "STRINGS.UI.TOOLTIPS.LOGICOVERLAYSTRING"
 msgid "Displays automation grid components {Hotkey}"
-msgstr "コロニーの自動化グリッド部品を表示します"
+msgstr "自動化グリッドの部品を表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_CODEX
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_CODEX"
-#| msgid "Browse entries in my Database"
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_CODEX"
 msgid "Browse entries in my Database {Hotkey}"
-msgstr "データベースを参照します"
+msgstr "データベースを参照します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_CONSUMABLES
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_CONSUMABLES"
-#| msgid "Manage colony diets"
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_CONSUMABLES"
 msgid "Manage colony diets {Hotkey}"
-msgstr "コロニーの食糧を管理します"
+msgstr "コロニーの食糧を管理します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_DAILYREPORT
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_DAILYREPORT"
-#| msgid "View each cycle's Colony Report"
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_DAILYREPORT"
 msgid "View each cycle's Colony Report {Hotkey}"
-msgstr "デイリーレポートを見ます"
+msgstr "コロニーのサイクル別のレポートを見ます{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_JOBS
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_JOBS"
@@ -12443,6 +12066,10 @@ msgid ""
 "Duplicants' priorities are calculated <i>before</i> specific errand priority "
 "set using the Priority tool."
 msgstr ""
+"複製人間の作業種別の優先度管理{Hotkey}\n"
+"------------------\n"
+"複製人間の優先度は優先度ツールで設定した特定作業の優先度より<i>後で</I>計算さ"
+"れます。"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_REQUIRES_RESEARCH
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_REQUIRES_RESEARCH"
@@ -12482,44 +12109,29 @@ msgstr ""
 "<color=#F44A47>[0]</color>にあります"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_RESEARCH
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_RESEARCH"
-#| msgid "View the Research Tree"
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_RESEARCH"
 msgid "View the Research Tree {Hotkey}"
-msgstr "研究ツリーを見ます"
+msgstr "研究ツリーを見ます{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_ROLES
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_ROLES"
-#| msgid "Manage Duplicants' job assignments"
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_ROLES"
 msgid "Manage Duplicants' job assignments {Hotkey}"
-msgstr "複製人間の職業割り当てを管理します"
+msgstr "複製人間の職業割り当てを管理します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_SCHEDULE
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_SCHEDULE"
-#| msgid "Adjust the colony's time usage"
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_SCHEDULE"
 msgid "Adjust the colony's time usage {Hotkey}"
-msgstr "コロニーのスケジュールを調整します"
+msgstr "コロニーのスケジュールを調整します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_STARMAP
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_STARMAP"
-#| msgid "Manage astronaut rocket missions"
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_STARMAP"
 msgid "Manage astronaut rocket missions {Hotkey}"
-msgstr "宇宙飛行士のロケットミッションを管理します"
+msgstr "宇宙飛行士のロケットミッションを管理します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_VITALS
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_VITALS"
-#| msgid "View my Duplicants' vitals"
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_VITALS"
 msgid "View my Duplicants' vitals {Hotkey}"
-msgstr "複製人間の健康状態を見ます"
+msgstr "複製人間の健康状態を見ます{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MATIERIAL_MOD
 msgctxt "STRINGS.UI.TOOLTIPS.MATIERIAL_MOD"
@@ -12553,12 +12165,9 @@ msgid "Population: {0}"
 msgstr "人口: {0}"
 
 #. STRINGS.UI.TOOLTIPS.MOPBUTTON
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.MOPBUTTON"
-#| msgid "Mop liquid spills"
 msgctxt "STRINGS.UI.TOOLTIPS.MOPBUTTON"
 msgid "Mop liquid spills {Hotkey}"
-msgstr "こぼれた液体をモップ掛けします"
+msgstr "こぼれた液体をモップ掛けします{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.NEXTMESSAGESTOOLTIP
 msgctxt "STRINGS.UI.TOOLTIPS.NEXTMESSAGESTOOLTIP"
@@ -12571,12 +12180,9 @@ msgid "No database entry available"
 msgstr "データベースの項目がありません"
 
 #. STRINGS.UI.TOOLTIPS.NOISE_POLLUTION_OVERLAY_STRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.NOISE_POLLUTION_OVERLAY_STRING"
-#| msgid "Displays ambient noise levels"
 msgctxt "STRINGS.UI.TOOLTIPS.NOISE_POLLUTION_OVERLAY_STRING"
 msgid "Displays ambient noise levels {Hotkey}"
-msgstr "大気中の騒音レベルを表示します"
+msgstr "大気中の騒音レベルを表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.NOMATERIAL
 msgctxt "STRINGS.UI.TOOLTIPS.NOMATERIAL"
@@ -12589,17 +12195,14 @@ msgid "View full entry in database"
 msgstr "データベースの全ての項目を参照します"
 
 #. STRINGS.UI.TOOLTIPS.OXYGENOVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.OXYGENOVERLAYSTRING"
-#| msgid "Displays ambient oxygen density"
 msgctxt "STRINGS.UI.TOOLTIPS.OXYGENOVERLAYSTRING"
 msgid "Displays ambient oxygen density {Hotkey}"
-msgstr "大気中の酸素濃度を表示します"
+msgstr "大気中の酸素濃度を表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.PAUSE
 msgctxt "STRINGS.UI.TOOLTIPS.PAUSE"
 msgid "Pause {Hotkey}"
-msgstr ""
+msgstr "一時停止{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.PAUSEBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.PAUSEBUTTON"
@@ -12612,20 +12215,14 @@ msgid "Start"
 msgstr "開始"
 
 #. STRINGS.UI.TOOLTIPS.POWEROVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.POWEROVERLAYSTRING"
-#| msgid "Displays power grid components"
 msgctxt "STRINGS.UI.TOOLTIPS.POWEROVERLAYSTRING"
 msgid "Displays power grid components {Hotkey}"
-msgstr "コロニーの配電状況を表示します"
+msgstr "コロニーの配電状況を表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.PRIORITIESOVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.PRIORITIESOVERLAYSTRING"
-#| msgid "Displays work priority values"
 msgctxt "STRINGS.UI.TOOLTIPS.PRIORITIESOVERLAYSTRING"
 msgid "Displays work priority values {Hotkey}"
-msgstr "作業の優先度を表示します"
+msgstr "作業の優先度を表示します{Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.PRIORITIZEBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.PRIORITIZEBUTTON"
@@ -12635,6 +12232,10 @@ msgid ""
 "Specific priority set from this tool are calculated <i>after</i> the "
 "Duplicants' priorities set on the Priorities Screen"
 msgstr ""
+"特定作業の優先度設定{Hotkey}\n"
+"------------------\n"
+"このツールで設定した特定優先度は優先度画面設定した複製人間の優先度より<I>後で"
+"</I>計算されます"
 
 #. STRINGS.UI.TOOLTIPS.PRIORITIZEMAINBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.PRIORITIZEMAINBUTTON"
@@ -12688,12 +12289,9 @@ msgid "Toggle Red Alert"
 msgstr "非常警報を切り替える"
 
 #. STRINGS.UI.TOOLTIPS.ROOMSOVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.ROOMSOVERLAYSTRING"
-#| msgid "Displays special purpose rooms and bonuses"
 msgctxt "STRINGS.UI.TOOLTIPS.ROOMSOVERLAYSTRING"
 msgid "Displays special purpose rooms and bonuses {Hotkey}"
-msgstr "特定の用途に特化した部屋とそのボーナスを表示します"
+msgstr "特定の用途に特化した部屋とそのボーナスを表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.SELECTAMATERIAL
 msgctxt "STRINGS.UI.TOOLTIPS.SELECTAMATERIAL"
@@ -12706,28 +12304,19 @@ msgid "Click to sort"
 msgstr "クリックしてソート"
 
 #. STRINGS.UI.TOOLTIPS.SPEEDBUTTON_FAST
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.SPEEDBUTTON_FAST"
-#| msgid "Fast speed {0}"
 msgctxt "STRINGS.UI.TOOLTIPS.SPEEDBUTTON_FAST"
 msgid "Fast speed {Hotkey}"
-msgstr "高速 {0}"
+msgstr "高速 {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.SPEEDBUTTON_MEDIUM
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.SPEEDBUTTON_MEDIUM"
-#| msgid "Medium speed {0}"
 msgctxt "STRINGS.UI.TOOLTIPS.SPEEDBUTTON_MEDIUM"
 msgid "Medium speed {Hotkey}"
-msgstr "中速 {0}"
+msgstr "中速 {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.SPEEDBUTTON_SLOW
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.SPEEDBUTTON_SLOW"
-#| msgid "Slow speed {0}"
 msgctxt "STRINGS.UI.TOOLTIPS.SPEEDBUTTON_SLOW"
 msgid "Slow speed {Hotkey}"
-msgstr "低速 {0}"
+msgstr "低速 {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.STATSPANEL
 msgctxt "STRINGS.UI.TOOLTIPS.STATSPANEL"
@@ -12757,28 +12346,19 @@ msgid ""
 msgstr "ストレスパネルは複製人間の心理状態に影響を及ぼすものを詳細に表示します"
 
 #. STRINGS.UI.TOOLTIPS.SUITOVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.SUITOVERLAYSTRING"
-#| msgid "Displays Exosuits and related buildings"
 msgctxt "STRINGS.UI.TOOLTIPS.SUITOVERLAYSTRING"
 msgid "Displays Exosuits and related buildings {Hotkey}"
-msgstr "EXOスーツおよび関連設備を表示します"
+msgstr "EXOスーツおよび関連設備を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.TEMPERATUREOVERLAYSTRING
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.TEMPERATUREOVERLAYSTRING"
-#| msgid "Displays ambient temperature"
 msgctxt "STRINGS.UI.TOOLTIPS.TEMPERATUREOVERLAYSTRING"
 msgid "Displays ambient temperature {Hotkey}"
-msgstr "大気温度を表示"
+msgstr "大気温度を表示 {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.UNPAUSE
-#, fuzzy
-#| msgctxt "STRINGS.UI.TOOLTIPS.UNPAUSE"
-#| msgid "Unpause"
 msgctxt "STRINGS.UI.TOOLTIPS.UNPAUSE"
 msgid "Unpause {Hotkey}"
-msgstr "一時停止を解除"
+msgstr "一時停止を解除 {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.VITALS_CHECKBOX_ATMOSPHERE
 msgctxt "STRINGS.UI.TOOLTIPS.VITALS_CHECKBOX_ATMOSPHERE"
@@ -13179,7 +12759,7 @@ msgstr "不適合"
 #. STRINGS.UI.UISIDESCREENS.COMETDETECTORSIDESCREEN.HEADER
 msgctxt "STRINGS.UI.UISIDESCREENS.COMETDETECTORSIDESCREEN.HEADER"
 msgid "Sends automation signal when selected object is detected"
-msgstr ""
+msgstr "選択した物質を検知した時に自動化シグナルを送信します"
 
 #. STRINGS.UI.UISIDESCREENS.COMETDETECTORSIDESCREEN.NOTHING
 msgctxt "STRINGS.UI.UISIDESCREENS.COMETDETECTORSIDESCREEN.NOTHING"
@@ -13551,12 +13131,9 @@ msgid "Recipe Details"
 msgstr "レシピ詳細"
 
 #. STRINGS.UI.UISIDESCREENS.FABRICATORSIDESCREEN.RECIPE_QUEUE
-#, fuzzy
-#| msgctxt "STRINGS.DUPLICANTS.ATTRIBUTES.FERTILITYDELTA.NAME"
-#| msgid "Reproduction Rate"
 msgctxt "STRINGS.UI.UISIDESCREENS.FABRICATORSIDESCREEN.RECIPE_QUEUE"
 msgid "Order Production Quantity:"
-msgstr "繁殖率"
+msgstr "製造指示量:"
 
 #. STRINGS.UI.UISIDESCREENS.FABRICATORSIDESCREEN.RECIPEPRODUCT
 msgctxt "STRINGS.UI.UISIDESCREENS.FABRICATORSIDESCREEN.RECIPEPRODUCT"
@@ -13787,46 +13364,37 @@ msgstr ""
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.CHORE_GROUP_SEPARATOR
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.CHORE_GROUP_SEPARATOR"
 msgid " or "
-msgstr ""
+msgstr "か"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.CHORE_TARGET
-#, fuzzy
-#| msgctxt "STRINGS.MISC.STATUSITEMS.USING.NAME"
-#| msgid "Using {Target}"
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.CHORE_TARGET"
 msgid "{Target}"
-msgstr "{Target} 使用中"
+msgstr "{Target}"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.CHORE_TARGET_AND_GROUP
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.CHORE_TARGET_AND_GROUP"
 msgid "{Target} -- {Groups}"
-msgstr ""
+msgstr "{Target} -- {Groups}"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.CURRENT_SCHEDULE_BLOCK
-#, fuzzy
-#| msgctxt "STRINGS.UI.DETAILTABS.NEEDS.CURRENT_NEED_LEVEL"
-#| msgid "Current Level: {0}"
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.CURRENT_SCHEDULE_BLOCK"
 msgid "Current schedule block: {0}"
-msgstr "現在の Level: {0}"
+msgstr "現在の予定ブロック: {0}"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.CURRENT_TITLE
-#, fuzzy
-#| msgctxt "STRINGS.BUILDING.STATUSITEMS.PENDINGHARVEST.NAME"
-#| msgid "Harvest Errand"
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.CURRENT_TITLE"
 msgid "Current Errand"
-msgstr "収穫作業"
+msgstr "現在の作業"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.LIST_TITLE
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.LIST_TITLE"
 msgid "\"To Do\" List"
-msgstr ""
+msgstr "ToDoリスト"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.SELF_LABEL
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.SELF_LABEL"
 msgid "Self"
-msgstr ""
+msgstr "自分"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_COMPULSORY
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_COMPULSORY"
@@ -13840,20 +13408,26 @@ msgid ""
 "\n"
 "Total Priority: {TotalPriority}"
 msgstr ""
+"{Description}\n"
+"\n"
+"{Errand}は強制の作業の為、すぐに行われます。\n"
+"\n"
+"強制: {ClassPriority}\n"
+"全ての{BestGroup}作業: {TypePriority}\n"
+"\n"
+"全体の優先度: {TotalPriority}"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_DESC_ACTIVE
-#, fuzzy
-#| msgctxt "STRINGS.UI.DETAILTABS.PERSONALITY.RESUME.CURRENT_ROLE.TOOLTIP"
-#| msgid "{0} is currently working as a {1}"
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_DESC_ACTIVE"
 msgid "{Name} is currently working on \"{Errand}\"."
-msgstr "{0}は現在{1}として働いています"
+msgstr "{Name}は現在{Errand}の作業をしています。"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_DESC_INACTIVE
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_DESC_INACTIVE"
 msgid ""
 "{Name} could work on \"{Errand}\", but it's not their top priority right now."
 msgstr ""
+"{Name}は\"{Errand}\"の作業が可能ですが、それは今は最優先ではありません。"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_EMERGENCY
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_EMERGENCY"
@@ -13869,6 +13443,15 @@ msgid ""
 "\n"
 "Total Priority: {TotalPriority}"
 msgstr ""
+"{Description}\n"
+"\n"
+"{Errand}は緊急の作業の為、全ての通常作業と個人作業よりも先に行われます。\n"
+"\n"
+"緊急: {ClassPriority}\n"
+"{Building}の優先度: {BuildingPriority}\n"
+"全ての{BestGroup}の作業: {TypePriority}\n"
+"\n"
+"全体の優先度: {TotalPriority}"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_IDLE
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_IDLE"
@@ -13882,14 +13465,19 @@ msgid ""
 "\n"
 "Total Priority: {TotalPriority}"
 msgstr ""
+"{IdleDescription}\n"
+"\n"
+"複製人間は他に何もする事が無い時にだけ{Errand}の作業を行います。\n"
+"\n"
+"待機: {ClassPriority}\n"
+"全ての{BestGroup}の作業: {TypePriority}\n"
+"\n"
+"全体の優先度: {TotalPriority}"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_IDLEDESC_ACTIVE
-#, fuzzy
-#| msgctxt "STRINGS.MISC.STATUSITEMS.USING.TOOLTIP"
-#| msgid "{Target} is currently in use"
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_IDLEDESC_ACTIVE"
 msgid "{Name} is currently idle."
-msgstr "{Target} は使用中です"
+msgstr "{Name}は現在待機中です。"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_IDLEDESC_INACTIVE
 msgctxt ""
@@ -13897,14 +13485,12 @@ msgctxt ""
 msgid ""
 "{Name} could become idle if all other errands are cancelled or completed."
 msgstr ""
+"{Name}は他の全ての作業がキャンセルもしくは完了した場合は待機状態になります。"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_NA
-#, fuzzy
-#| msgctxt "STRINGS.UI.UISIDESCREENS.ASSIGNABLESIDESCREEN.UNASSIGNED"
-#| msgid "-"
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_NA"
 msgid "--"
-msgstr "-"
+msgstr "--"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_NORMAL
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_NORMAL"
@@ -13919,6 +13505,15 @@ msgid ""
 "\n"
 "Total Priority: {TotalPriority}"
 msgstr ""
+"{Description}\n"
+"\n"
+"{Errand}の種類: {Groups}\n"
+"\n"
+"{Name}の{BestGroup}の優先度: {PersonalPriorityValue} ({PersonalPriority})\n"
+"{Building}の優先度: {BuildingPriority}\n"
+"全ての{BestGroup}の優先度: {TypePriority}\n"
+"\n"
+"全体の優先度: {TotalPriority}"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_PERSONAL
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TOOLTIP_PERSONAL"
@@ -13933,14 +13528,19 @@ msgid ""
 "\n"
 "Total Priority: {TotalPriority}"
 msgstr ""
+"{Description}\n"
+"\n"
+"{Errand}は個人的な需要の作業の為、全ての通常作業より先に行われます。\n"
+"\n"
+"個人的な需要: {ClassPriority}\n"
+"全ての{BestGroup}の作業: {TypePriority}\n"
+"\n"
+"全体の優先度: {TotalPriority}"
 
 #. STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TRUNCATED_CHORES
-#, fuzzy
-#| msgctxt "STRINGS.UI.STARMAP.DISTANCE"
-#| msgid "{0} km"
 msgctxt "STRINGS.UI.UISIDESCREENS.MINIONTODOSIDESCREEN.TRUNCATED_CHORES"
 msgid "{0} more"
-msgstr "{0} km"
+msgstr "{0}以上"
 
 #. STRINGS.UI.UISIDESCREENS.OIL_WELL_CAP_SIDE_SCREEN.TITLE
 msgctxt "STRINGS.UI.UISIDESCREENS.OIL_WELL_CAP_SIDE_SCREEN.TITLE"
@@ -14328,12 +13928,9 @@ msgid "Next Production: {0}"
 msgstr "次の生産物: {0}"
 
 #. STRINGS.UI.UISIDESCREENS.TELEPADSIDESCREEN.TITLE
-#, fuzzy
-#| msgctxt "STRINGS.MISC.TAGS.UNSTABLE"
-#| msgid "Unstable"
 msgctxt "STRINGS.UI.UISIDESCREENS.TELEPADSIDESCREEN.TITLE"
 msgid "Printables"
-msgstr "不安定"
+msgstr "製造物"
 
 #. STRINGS.UI.UISIDESCREENS.TELESCOPESIDESCREEN.ANALYSIS_TARGET_HEADER
 msgctxt "STRINGS.UI.UISIDESCREENS.TELESCOPESIDESCREEN.ANALYSIS_TARGET_HEADER"
@@ -15040,16 +14637,11 @@ msgid "Copy Settings"
 msgstr "設定をコピー"
 
 #. STRINGS.UI.USERMENUACTIONS.COPY_BUILDING_SETTINGS.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.USERMENUACTIONS.COPY_BUILDING_SETTINGS.TOOLTIP"
-#| msgid ""
-#| "Apply the settings and priorities of this building to other buildings of "
-#| "the same type"
 msgctxt "STRINGS.UI.USERMENUACTIONS.COPY_BUILDING_SETTINGS.TOOLTIP"
 msgid ""
 "Apply the settings and priorities of this building to other buildings of the "
 "same type {Hotkey}"
-msgstr "この設備の設定と優先度を他の同じタイプの設備にコピーします"
+msgstr "この設備の設定と優先度を他の同じタイプの設備にコピーします{Hotkey}"
 
 #. STRINGS.UI.USERMENUACTIONS.DEMOLISH.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.DEMOLISH.NAME"
@@ -15158,29 +14750,20 @@ msgid "Enable Building"
 msgstr "設備有効化"
 
 #. STRINGS.UI.USERMENUACTIONS.ENABLEBUILDING.TOOLTIP
-#, fuzzy
-#| msgctxt "STRINGS.UI.USERMENUACTIONS.ENABLEBUILDING.TOOLTIP"
-#| msgid ""
-#| "Halt the use of this building\n"
-#| "------------------\n"
-#| "Disabled buildings consume no energy or resources"
 msgctxt "STRINGS.UI.USERMENUACTIONS.ENABLEBUILDING.TOOLTIP"
 msgid ""
 "Halt the use of this building {Hotkey}\n"
 "------------------\n"
 "Disabled buildings consume no energy or resources"
 msgstr ""
-"この設備の使用を停止します\n"
+"この設備の使用を停止します{Hotkey}\n"
 "------------------\n"
 "停止中の設備は電力や資源を消費しません"
 
 #. STRINGS.UI.USERMENUACTIONS.ENABLEBUILDING.TOOLTIP_OFF
-#, fuzzy
-#| msgctxt "STRINGS.UI.USERMENUACTIONS.ENABLEBUILDING.TOOLTIP_OFF"
-#| msgid "Resume the use of this building"
 msgctxt "STRINGS.UI.USERMENUACTIONS.ENABLEBUILDING.TOOLTIP_OFF"
 msgid "Resume the use of this building {Hotkey}"
-msgstr "この設備の使用を再開します"
+msgstr "この設備の使用を再開します{Hotkey}"
 
 #. STRINGS.UI.USERMENUACTIONS.FOLLOWCAM.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.FOLLOWCAM.NAME"
@@ -15826,12 +15409,9 @@ msgid "Select to make Duplicants wash when passing by from left to right"
 msgstr "複製人間がこの設備を左から右に通り過ぎるときに洗浄させます"
 
 #. STRINGS.UI.VIEWDUPLICANTS
-#, fuzzy
-#| msgctxt "STRINGS.UI.VIEWDUPLICANTS"
-#| msgid "Choose a Duplicant"
 msgctxt "STRINGS.UI.VIEWDUPLICANTS"
 msgid "Choose a Blueprint"
-msgstr "複製人間選択"
+msgstr "設計図を選択"
 
 #. STRINGS.UI.VITALS
 msgctxt "STRINGS.UI.VITALS"

--- a/po/ui.po
+++ b/po/ui.po
@@ -3253,7 +3253,7 @@ msgstr "コロニーは一日を通して<link=\"FOOD\">食糧</link>を{0}生�
 #. STRINGS.UI.ENDOFDAYREPORT.CHORE_STATUS.NAME
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.CHORE_STATUS.NAME"
 msgid "Chores:"
-msgstr "作業"
+msgstr "作業:"
 
 #. STRINGS.UI.ENDOFDAYREPORT.CHORE_STATUS.NEGATIVE_TOOLTIP
 msgctxt "STRINGS.UI.ENDOFDAYREPORT.CHORE_STATUS.NEGATIVE_TOOLTIP"
@@ -10044,7 +10044,8 @@ msgstr "設定"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.AMELIASWATCH.DESCRIPTION"
 msgid ""
 "It was discovered in a package labeled \"To be entrusted to Dr. Walker\"."
-msgstr "それは\"Dr.ウォーカーへ委託\"とラベルが貼られた箱の中から見つかった。"
+msgstr ""
+"それは\"Dr.ウォーカーへ委託\"とラベルが貼られた箱の中から見つかりました。"
 
 #. STRINGS.UI.SPACEARTIFACTS.AMELIASWATCH.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.AMELIASWATCH.NAME"
@@ -10092,8 +10093,8 @@ msgid ""
 "A thriving colony of tiny, microscopic organisms is responsible for giving "
 "it its bluish glow."
 msgstr ""
-"あるちっぽけな、顕微鏡レベルの生物が繁栄するコロニーには、その青みを帯びた輝"
-"きを与える責任がある。"
+"青みを帯びた発光は、ちっぽけな顕微鏡レベルの生物が繁茂するコロニーによるもの"
+"です。"
 
 #. STRINGS.UI.SPACEARTIFACTS.BIOLUMROCK.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.BIOLUMROCK.NAME"
@@ -10106,7 +10107,7 @@ msgid ""
 "Equipment used to conduct experiments answering the age-old question, "
 "\"Could that blend\"?"
 msgstr ""
-"古くからある質問、\"混ぜてもいいか？\"に答えるための実験を行うための機器。"
+"古くからある質問、\"混ぜてもいいか？\"に答えるための実験を行うための機器です"
 
 #. STRINGS.UI.SPACEARTIFACTS.BLENDER.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.BLENDER.NAME"
@@ -10116,7 +10117,7 @@ msgstr "撹拌機"
 #. STRINGS.UI.SPACEARTIFACTS.BRICKPHONE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.BRICKPHONE.DESCRIPTION"
 msgid "It still works."
-msgstr "まだ動く。"
+msgstr "まだ動きます。"
 
 #. STRINGS.UI.SPACEARTIFACTS.BRICKPHONE.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.BRICKPHONE.NAME"
@@ -10126,7 +10127,7 @@ msgstr "奇妙なガラケー"
 #. STRINGS.UI.SPACEARTIFACTS.DNAMODEL.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.DNAMODEL.DESCRIPTION"
 msgid "An educational model of genetic information."
-msgstr "遺伝情報の教育モデル"
+msgstr "遺伝情報の教育モデルです。"
 
 #. STRINGS.UI.SPACEARTIFACTS.DNAMODEL.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.DNAMODEL.NAME"
@@ -10139,7 +10140,8 @@ msgid ""
 "It's unclear whether this is its naturally occurring shape, or if its "
 "appearance as been sculpted."
 msgstr ""
-"これが自然にそのような形になったのか、そのような形に彫刻されたのかは不明だ。"
+"これが自然にそのような形になったのか、そのような形に彫刻されたのかは不明で"
+"す。"
 
 #. STRINGS.UI.SPACEARTIFACTS.EGGROCK.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.EGGROCK.NAME"
@@ -10149,7 +10151,7 @@ msgstr "卵型の岩"
 #. STRINGS.UI.SPACEARTIFACTS.HATCHFOSSIL.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.HATCHFOSSIL.DESCRIPTION"
 msgid "The preserved bones of an early species of Hatch."
-msgstr "ハッチ初期種の保存された骨"
+msgstr "ハッチ初期種の保存された骨です。"
 
 #. STRINGS.UI.SPACEARTIFACTS.HATCHFOSSIL.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.HATCHFOSSIL.NAME"
@@ -10159,7 +10161,7 @@ msgstr "自然のままの化石"
 #. STRINGS.UI.SPACEARTIFACTS.MAGMALAMP.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MAGMALAMP.DESCRIPTION"
 msgid "The sequel to \"Lava Lamp\"."
-msgstr "\"溶岩ランプ\"の後編。"
+msgstr "\"溶岩ランプ\"の後継品。"
 
 #. STRINGS.UI.SPACEARTIFACTS.MAGMALAMP.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MAGMALAMP.NAME"
@@ -10180,7 +10182,7 @@ msgstr "近代美術"
 #. STRINGS.UI.SPACEARTIFACTS.MOLDAVITE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MOLDAVITE.DESCRIPTION"
 msgid "A unique green stone formed from the impact of a meteorite."
-msgstr "隕石の衝撃で形成されたユニークな緑色の石。"
+msgstr "隕石の衝撃で形成されたユニークな緑色の石です。"
 
 #. STRINGS.UI.SPACEARTIFACTS.MOLDAVITE.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MOLDAVITE.NAME"
@@ -10190,7 +10192,7 @@ msgstr "モルダバイト"
 #. STRINGS.UI.SPACEARTIFACTS.MOONMOONMOON.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MOONMOONMOON.DESCRIPTION"
 msgid "A moon's moon's moon. It's very small."
-msgstr "月の月の月。とても小さい。"
+msgstr "月の月の月。とても小さいです。"
 
 #. STRINGS.UI.SPACEARTIFACTS.MOONMOONMOON.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MOONMOONMOON.NAME"
@@ -10206,7 +10208,7 @@ msgid ""
 msgstr ""
 "長方形の石片。\n"
 "\n"
-"その機能は不明だ。"
+"その機能は不明です。"
 
 #. STRINGS.UI.SPACEARTIFACTS.OBELISK.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.OBELISK.NAME"
@@ -10217,7 +10219,7 @@ msgstr "小さなオベリスク"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.OFFICEMUG.DESCRIPTION"
 msgid ""
 "An intermediary place to store espresso before you move it to your mouth."
-msgstr "エスプレッソを口に運ぶ前に保管する中間の場所。"
+msgstr "エスプレッソを口に運ぶ前に保管する中間の場所です。"
 
 #. STRINGS.UI.SPACEARTIFACTS.OFFICEMUG.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.OFFICEMUG.NAME"
@@ -10237,7 +10239,7 @@ msgstr "古いレントゲン"
 #. STRINGS.UI.SPACEARTIFACTS.PERCOLATOR.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.PERCOLATOR.DESCRIPTION"
 msgid "Don't drink from it! There was a pacu... IN the percolator!"
-msgstr "それから飲んでは駄目だ！そのコーヒー沸かしの中にパクーが居たんだ…"
+msgstr "それから飲んでは駄目だ！そのコーヒー沸かしの中にパクーが居たんだ…！"
 
 # Prospect + lator
 #. STRINGS.UI.SPACEARTIFACTS.PERCOLATOR.NAME
@@ -10248,7 +10250,7 @@ msgstr "濾過装置付きコーヒー沸かし"
 #. STRINGS.UI.SPACEARTIFACTS.PLASMALAMP.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.PLASMALAMP.DESCRIPTION"
 msgid "No space colony is complete without one."
-msgstr "それなしではスペースコロニーは完成しない。"
+msgstr "それなしではスペースコロニーは完成しません。"
 
 #. STRINGS.UI.SPACEARTIFACTS.PLASMALAMP.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.PLASMALAMP.NAME"
@@ -10263,10 +10265,10 @@ msgid ""
 "\n"
 "This one is rainbow coloured."
 msgstr ""
-"これが自然にそのような形になったのか、そのような形に彫刻されたのかは不明"
-"だ。\n"
+"これが自然にそのような形になったのか、そのような形に彫刻されたのかは不明で"
+"す。\n"
 "\n"
-"これは虹色だ。"
+"これは虹色です。"
 
 #. STRINGS.UI.SPACEARTIFACTS.RAINBOWEGGROCK.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.RAINBOWEGGROCK.NAME"
@@ -10276,7 +10278,7 @@ msgstr "卵型の岩"
 #. STRINGS.UI.SPACEARTIFACTS.ROBOTARM.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ROBOTARM.DESCRIPTION"
 msgid "It's not functional. Just cool."
-msgstr "機能的では無い。かっこいいだけ。"
+msgstr "機能的ではありません。かっこいいだけ。"
 
 #. STRINGS.UI.SPACEARTIFACTS.ROBOTARM.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ROBOTARM.NAME"
@@ -10286,7 +10288,7 @@ msgstr "ロボットアーム"
 #. STRINGS.UI.SPACEARTIFACTS.ROCKTORNADO.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ROCKTORNADO.DESCRIPTION"
 msgid "It's unclear how it formed, although I'm glad it did."
-msgstr "どのように形成されたかは不明だ、でもそうなったのが嬉しい。"
+msgstr "どのように形成されたかは不明です、でもそうなったのが嬉しい。"
 
 #. STRINGS.UI.SPACEARTIFACTS.ROCKTORNADO.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ROCKTORNADO.NAME"
@@ -10296,7 +10298,7 @@ msgstr "トルネードロック"
 #. STRINGS.UI.SPACEARTIFACTS.RUBIKSCUBE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.RUBIKSCUBE.DESCRIPTION"
 msgid "This mystery of the universe has already been solved."
-msgstr "この宇宙の謎は既に解決した。"
+msgstr "この宇宙の謎は既に解決しました。"
 
 #. STRINGS.UI.SPACEARTIFACTS.RUBIKSCUBE.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.RUBIKSCUBE.NAME"
@@ -10306,7 +10308,7 @@ msgstr "ルービックキューブ"
 #. STRINGS.UI.SPACEARTIFACTS.SANDSTONE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SANDSTONE.DESCRIPTION"
 msgid "A beautiful rock composed of multiple layers of sediment."
-msgstr "堆積物が幾重にも重なってできた美しい岩。"
+msgstr "堆積物が幾重にも重なってできた美しい岩です。"
 
 #. STRINGS.UI.SPACEARTIFACTS.SANDSTONE.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SANDSTONE.NAME"
@@ -10316,7 +10318,7 @@ msgstr "砂岩"
 #. STRINGS.UI.SPACEARTIFACTS.SAXOPHONE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SAXOPHONE.DESCRIPTION"
 msgid "The name \"Pesquet\" is barely legible on the inside."
-msgstr "\"ペスケ\"という名前は、内側ではほとんど判読出来ない。"
+msgstr "\"ペスケ\"という名前は、内側ではほとんど判読出来ません。"
 
 #. STRINGS.UI.SPACEARTIFACTS.SAXOPHONE.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SAXOPHONE.NAME"
@@ -10327,7 +10329,7 @@ msgstr "ずたずたのサクソフォン"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SHIELDGENERATOR.DESCRIPTION"
 msgid ""
 "A mechanical prototype capable of producing a small section of shielding."
-msgstr "シールドの小さな部分を作り出すことが出来るメカニカルな試作品"
+msgstr "シールドの小さな部分を作り出すことが出来るメカニカルな試作品です。"
 
 #. STRINGS.UI.SPACEARTIFACTS.SHIELDGENERATOR.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SHIELDGENERATOR.NAME"
@@ -10337,7 +10339,7 @@ msgstr "シールド生成器"
 #. STRINGS.UI.SPACEARTIFACTS.SINK.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SINK.DESCRIPTION"
 msgid "No collection is complete without it."
-msgstr "それなしではコレクションは完成しない。"
+msgstr "それなしではコレクションは完成しません。"
 
 #. STRINGS.UI.SPACEARTIFACTS.SINK.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SINK.NAME"
@@ -10349,7 +10351,7 @@ msgctxt "STRINGS.UI.SPACEARTIFACTS.SOLARSYSTEM.DESCRIPTION"
 msgid ""
 "A marvel of the cosmos, inside this display is an entirely self-contained "
 "solar system."
-msgstr "このディスプレイの中の宇宙の驚異は、完全な自己完結型の太陽光発電だ。"
+msgstr "このディスプレイの中の宇宙の驚異は、完全な自己完結型の太陽光発電です。"
 
 #. STRINGS.UI.SPACEARTIFACTS.SOLARSYSTEM.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SOLARSYSTEM.NAME"
@@ -10359,7 +10361,7 @@ msgstr "自己完結型のシステム"
 #. STRINGS.UI.SPACEARTIFACTS.STETHOSCOPE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.STETHOSCOPE.DESCRIPTION"
 msgid "Listens to Duplicant heartbeats, or gurgley tummies."
-msgstr "複製人間の心拍や、ゴロゴロ鳴るお腹を聴く。"
+msgstr "複製人間の心拍や、ゴロゴロ鳴るお腹を聴きます。"
 
 #. STRINGS.UI.SPACEARTIFACTS.STETHOSCOPE.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.STETHOSCOPE.NAME"
@@ -10370,7 +10372,7 @@ msgstr "聴診器"
 msgctxt "STRINGS.UI.SPACEARTIFACTS.TEAPOT.DESCRIPTION"
 msgid ""
 "A teapot from the depths of space, coated in a thick layer of Neutronium."
-msgstr "厚いニュートロニウムの層で覆われた、宇宙の深層のティーポット。"
+msgstr "厚いニュートロニウムの層で覆われた、宇宙の深層のティーポットです。"
 
 #. STRINGS.UI.SPACEARTIFACTS.TEAPOT.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.TEAPOT.NAME"
@@ -10380,7 +10382,7 @@ msgstr "覆われたティーポット"
 #. STRINGS.UI.SPACEARTIFACTS.VHS.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.VHS.DESCRIPTION"
 msgid "Be kind when you handle it. It's very fragile."
-msgstr "それを取り扱う時は優しくしなさい。とても壊れやすい。"
+msgstr "それを取り扱う時は優しくしましょう。とても壊れやすいです。"
 
 #. STRINGS.UI.SPACEARTIFACTS.VHS.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.VHS.NAME"


### PR DESCRIPTION
HotKeyの追加のみの所が結構あったので、変更点は行数ほど多くはありません。
Choreは仕事？業務？作業？で迷ったのですが、一旦作業で統一しています。
追加された緊急度のCompulsory、Emergency、Urgentは訳語が被るのですが、それぞれ「強制」「緊急」「急ぎ」にしています。

SPACEARTIFACTS関連はどう訳すか迷う所が多かったので重点的に確認頂いた方が良いかと思います。
Strange BrickはIDのBrick phoneで検索すると古い携帯のようだったので「奇妙なガラケー」
Percolatorはそのままパーコレーターですが多分伝わらないので「濾過装置付きコーヒー沸かし」
Moonmoonmoonは車のZoomZoomZoomと掛けているのだと思いますが適当な訳が見つからないのでそのままカタカナ
Solar Systemは太陽系？太陽光発電？ 一旦「太陽光発電」に、等々。