### PR TITLE
宇宙飛行士のトマ・ペスケにちなんだ訳に変更

### DIFF
--- a/po/ui.po
+++ b/po/ui.po
@@ -10318,7 +10318,7 @@ msgstr "砂岩"
 #. STRINGS.UI.SPACEARTIFACTS.SAXOPHONE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SAXOPHONE.DESCRIPTION"
 msgid "The name \"Pesquet\" is barely legible on the inside."
-msgstr "\"ペスケ\"という名前は、内側ではほとんど判読出来ません。"
+msgstr "内側に\"ペスケ\"という名前が、なんとか判読できます。"
 
 #. STRINGS.UI.SPACEARTIFACTS.SAXOPHONE.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SAXOPHONE.NAME"


### PR DESCRIPTION
ISSの中で誕生日のサプライズにサックスを送られた宇宙飛行士トマ・ペスケのサックスだとリスペクトがわかる翻訳に変更しました。
検討お願いします。