### PR TITLE
細かめの訳語の選択ミスだと思われるものを修正

### DIFF
--- a/po/ui.po
+++ b/po/ui.po
@@ -10156,12 +10156,12 @@ msgstr "ハッチ初期種の保存された骨です。"
 #. STRINGS.UI.SPACEARTIFACTS.HATCHFOSSIL.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.HATCHFOSSIL.NAME"
 msgid "Pristine Fossil"
-msgstr "自然のままの化石"
+msgstr "原始の化石"
 
 #. STRINGS.UI.SPACEARTIFACTS.MAGMALAMP.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MAGMALAMP.DESCRIPTION"
 msgid "The sequel to \"Lava Lamp\"."
-msgstr "\"溶岩ランプ\"の後継品。"
+msgstr "\"ラバランプ\"の後継品。"
 
 #. STRINGS.UI.SPACEARTIFACTS.MAGMALAMP.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.MAGMALAMP.NAME"
@@ -10351,12 +10351,12 @@ msgctxt "STRINGS.UI.SPACEARTIFACTS.SOLARSYSTEM.DESCRIPTION"
 msgid ""
 "A marvel of the cosmos, inside this display is an entirely self-contained "
 "solar system."
-msgstr "このディスプレイの中の宇宙の驚異は、完全な自己完結型の太陽光発電です。"
+msgstr "驚異的なことに、この展示の中の宇宙は完全に自己完結した恒星系です。"
 
 #. STRINGS.UI.SPACEARTIFACTS.SOLARSYSTEM.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.SOLARSYSTEM.NAME"
 msgid "Self-Contained System"
-msgstr "自己完結型のシステム"
+msgstr "自己完結型システム"
 
 #. STRINGS.UI.SPACEARTIFACTS.STETHOSCOPE.DESCRIPTION
 msgctxt "STRINGS.UI.SPACEARTIFACTS.STETHOSCOPE.DESCRIPTION"


### PR DESCRIPTION
Pristine→原始の
元々の意味が「初期の状態の」という意味のラテン語由来らしく、そこから派生して「手付かず」とか「自然の」と意味が派生したらしいのです。この場合原始的なハッチの化石ということなので「原始の」と訳すのが正解だと思います。

Lava Lamp→ラバランプ
インテリア照明として「ラバランプ」というカテゴリーがあります。この場合、溶岩と訳さずにそのまま「ラバランプ」と書くのが正解だと思われます。

solar system→太陽系
`solar system` は直訳では太陽系です。ですが、この場合太陽ではないので「恒星系」と訳すのが良いと思います。

以上3点検討お願いします。