### PR TITLE
Overlapの翻訳を「重なる」「重なり」に統一

### DIFF
--- a/po/building.po
+++ b/po/building.po
@@ -1150,17 +1150,17 @@ msgstr "この場所に設備を建設することはできません"
 #. STRINGS.BUILDING.STATUSITEMS.INVALIDPORTOVERLAP.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.INVALIDPORTOVERLAP.NAME"
 msgid "Invalid Port Overlap"
-msgstr "不正な入出力オーバーラップ"
+msgstr "不正な入出力の重なり"
 
 #. STRINGS.BUILDING.STATUSITEMS.INVALIDPORTOVERLAP.NOTIFICATION_NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.INVALIDPORTOVERLAP.NOTIFICATION_NAME"
 msgid "Building has overlapping ports"
-msgstr "設備の入出力がオーバーラップしています"
+msgstr "設備の入出力が重なっています"
 
 #. STRINGS.BUILDING.STATUSITEMS.INVALIDPORTOVERLAP.NOTIFICATION_TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.INVALIDPORTOVERLAP.NOTIFICATION_TOOLTIP"
 msgid "These buildings must be rebuilt with non-overlapping ports:"
-msgstr "これらの設備は入出力が被らないように再建設する必要があります:"
+msgstr "これらの設備は入出力が重ならないように再建設する必要があります:"
 
 #. STRINGS.BUILDING.STATUSITEMS.INVALIDPORTOVERLAP.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.INVALIDPORTOVERLAP.TOOLTIP"
@@ -1169,7 +1169,7 @@ msgid ""
 "------------------\n"
 "This building must be rebuilt in a valid location"
 msgstr ""
-"この設備の入出力は他の設備と被っています。\n"
+"この設備の入出力は他の設備と重なっています。\n"
 "------------------\n"
 "正しい場所に再建設する必要があります。"
 


### PR DESCRIPTION
Overlapの翻訳の大部分は「重なる」となっていますが、一部「被る」「オーバーラップする」と訳されていたので、「重なる」の方に翻訳を寄せました。
検討お願いします。