### PR TITLE
Anemicの翻訳と説明がゲーム内の内容とずれていたので修正しました

### DIFF
--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -8634,12 +8634,12 @@ msgstr "• ストレス60%以上になると設備を修理しなくなりま�
 #. STRINGS.DUPLICANTS.TRAITS.ANEMIC.DESC
 msgctxt "STRINGS.DUPLICANTS.TRAITS.ANEMIC.DESC"
 msgid "This Duplicant has trouble keeping up with the others"
-msgstr "この複製人間は他人とうまくやっていくことに問題を抱えています"
+msgstr "この複製人間は皆に遅れずについていくことが困難です"
 
 #. STRINGS.DUPLICANTS.TRAITS.ANEMIC.NAME
 msgctxt "STRINGS.DUPLICANTS.TRAITS.ANEMIC.NAME"
 msgid "Anemic"
-msgstr "無気力"
+msgstr "貧血"
 
 #. STRINGS.DUPLICANTS.TRAITS.ANXIOUS.DESC
 msgctxt "STRINGS.DUPLICANTS.TRAITS.ANXIOUS.DESC"


### PR DESCRIPTION
`Anemic` は医学用語の方の「貧血」で訳した方がしっくり来ると思います。
貧血で速く走れない → 運動特性 -5 ということだと思います。
よくサボるとか、休憩を多く要求するとかだったら「無気力」でもよかったのですがこの場合「貧血」かなと。
`keeping up with` の訳も「遅れずについていく」という訳になると思います。