### PR TITLE
Field Researchの訳を「野外調査」から「実地調査」に変更

### DIFF
--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -7664,7 +7664,7 @@ msgstr "複製人間は<style=\"KKeyword\">間欠泉</style>や他の現象を�
 #. STRINGS.DUPLICANTS.ROLES.RESEARCHER.NAME
 msgctxt "STRINGS.DUPLICANTS.ROLES.RESEARCHER.NAME"
 msgid "<link=\"RESEARCHER\">Field Research</link>"
-msgstr "<link=\"RESEARCHER\">野外調査</link>"
+msgstr "<link=\"RESEARCHER\">実地調査</link>"
 
 #. STRINGS.DUPLICANTS.ROLES.SENIOR_BUILDER.DESCRIPTION
 msgctxt "STRINGS.DUPLICANTS.ROLES.SENIOR_BUILDER.DESCRIPTION"

--- a/strings.po
+++ b/strings.po
@@ -32532,7 +32532,7 @@ msgstr "複製人間は<style=\"KKeyword\">間欠泉</style>や他の現象を�
 #. STRINGS.DUPLICANTS.ROLES.RESEARCHER.NAME
 msgctxt "STRINGS.DUPLICANTS.ROLES.RESEARCHER.NAME"
 msgid "<link=\"RESEARCHER\">Field Research</link>"
-msgstr "<link=\"RESEARCHER\">野外調査</link>"
+msgstr "<link=\"RESEARCHER\">実地調査</link>"
 
 #. STRINGS.DUPLICANTS.ROLES.SENIOR_BUILDER.DESCRIPTION
 msgctxt "STRINGS.DUPLICANTS.ROLES.SENIOR_BUILDER.DESCRIPTION"


### PR DESCRIPTION
この地下と宇宙しかないゲームに「野外」という概念がそぐわない気がしたので変更案を作ってみました。
研究テーブルを離れての調査をするよという意味で「実地調査」という訳にしてみました。