### PR TITLE
Alternate Pod Location

### DIFF
--- a/po/world_traits.po
+++ b/po/world_traits.po
@@ -191,7 +191,7 @@ msgstr ""
 #. STRINGS.WORLD_TRAITS.MISALIGNED_START.NAME
 msgctxt "STRINGS.WORLD_TRAITS.MISALIGNED_START.NAME"
 msgid "Alternate Pod Location"
-msgstr "見当違いな製造ポッド"
+msgstr "製造ポッドの座標エラー"
 
 #. STRINGS.WORLD_TRAITS.MISSING_TRAIT
 msgctxt "STRINGS.WORLD_TRAITS.MISSING_TRAIT"


### PR DESCRIPTION
和訳にLocation要素がないため。 こんな感じでどうでしょう。