### PR TITLE
colony_achievements.po の更新

### DIFF
--- a/po/colony_achievements.po
+++ b/po/colony_achievements.po
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4.2\n"
+"X-Generator: Poedit 2.4.3\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
@@ -37,10 +37,10 @@ msgid ""
 "Temporal Tear carrying that hope on their shoulders... Perhaps one day "
 "they'll find a place to call home, and begin a thriving colony all their own."
 msgstr ""
-"この宇宙にあった故郷の惑星は失われ、残骸と傷跡を残すのみとなった。しかし私は"
-"別の次元にまだ故郷が存在している可能性を信じている。時間の裂け目に送り出した"
-"複製人間の肩に一縷の望みを託した。いつの日か、彼らは故郷と呼べる場所を見つけ"
-"るだろう。そして彼らは自身のコロニーを繁栄させるのだ。"
+"この宇宙にあった我らが故郷は消え去り、あとには惑星の残骸と空に浮かぶ傷跡が残"
+"された…。しかし私は希望を信じる。別の世界が、異なる次元に隠れて存在すること"
+"を。私は、その希望を背負った複製人間を時間の裂け目から送り出した…。いつの日"
+"か、彼らは故郷と呼べる場所を見つけ、自分たちのコロニーを繁栄させるだろう。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.DISTANT_PLANET_REACHED.MESSAGE_BODY_DLC1
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.DISTANT_PLANET_REACHED.MESSAGE_BODY_DLC1"
@@ -80,7 +80,7 @@ msgctxt ""
 "REACHED_SPACE_DESTINATION_DESCRIPTION"
 msgid ""
 "Send a Duplicant on a one-way mission to the furthest Starmap destination"
-msgstr "複製人間を星図の最も遠い場所へと送り出す、片道ミッションを実施する"
+msgstr "星図の最も遠い場所へ向けて、複製人間を片道ミッションに送り出す"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.DISTANT_PLANET_REACHED.VIDEO_TEXT.FIRST
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.DISTANT_PLANET_REACHED.VIDEO_TEXT.FIRST"
@@ -89,8 +89,9 @@ msgid ""
 "and a wound in the sky... But I hold out hope that other worlds exist out "
 "there, tucked away in other dimensions."
 msgstr ""
-"この宇宙にあった故郷の惑星は失われ、残骸と傷跡を残すのみとなった。しかし私は"
-"別の次元にまだ故郷が存在している可能性を信じている。"
+"この宇宙にあった我らが故郷は消え去り、あとには惑星の残骸と空に浮かぶ傷跡が残"
+"された…。しかし私は希望を信じる。別の世界が、異なる次元に隠れて存在すること"
+"を。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.DISTANT_PLANET_REACHED.VIDEO_TEXT.SECOND
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.DISTANT_PLANET_REACHED.VIDEO_TEXT.SECOND"
@@ -99,9 +100,8 @@ msgid ""
 "shoulders... Perhaps one day they'll find a place to call home, and begin a "
 "thriving colony all their own."
 msgstr ""
-"時間の裂け目に送り出した複製人間の肩に一縷の望みを託した。いつの日か、彼らは"
-"故郷と呼べる場所を見つけるだろう。そして彼らは自身のコロニーを繁栄させるの"
-"だ。"
+"私は、その希望を背負った複製人間を時間の裂け目から送り出した…。いつの日か、彼"
+"らは故郷と呼べる場所を見つけ、自分たちのコロニーを繁栄させるだろう。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.DISTANT_PLANET_REACHED.VIDEO_TEXT_DLC1.FIRST
 msgctxt ""
@@ -123,7 +123,7 @@ msgstr "現在のコロニーはこの取り組みを達成していません"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.AUTOMATE_A_BUILDING
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.AUTOMATE_A_BUILDING"
 msgid "Red Light, Green Light"
-msgstr "レッド、グリーン"
+msgstr "赤い信号、緑の信号"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.AUTOMATE_A_BUILDING_DESCRIPTION
 msgctxt ""
@@ -143,7 +143,7 @@ msgstr "ベッドとトイレ"
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.BASIC_COMFORTS_DESCRIPTION"
 msgid "Have at least one toilet in the colony and a bed for every Duplicant."
-msgstr "1個以上のトイレを設置し、複製人間全員にベッドを支給する。"
+msgstr "1つ以上のトイレを設置し、複製人間全員にベッドを割り当てる。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.BASIC_PUMPING
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.BASIC_PUMPING"
@@ -159,19 +159,19 @@ msgstr "通風口を通じて酸素を1000kg供給する。"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.BUILD_NATURE_RESERVES
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.BUILD_NATURE_RESERVES"
 msgid "Some Reservations"
-msgstr "建設予定地"
+msgstr "保護区群"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.BUILD_NATURE_RESERVES_DESCRIPTION
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS."
 "BUILD_NATURE_RESERVES_DESCRIPTION"
 msgid "Improve Duplicant Morale by designating {1} areas as {0}."
-msgstr "{1}エリアを{0}にすることで複製人間の士気を改善する。"
+msgstr "{1}エリアを{0}にすることで複製人間の士気を向上させる。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.BUILD_OUTSIDE_BIOME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.BUILD_OUTSIDE_BIOME"
 msgid "Outdoor Renovations"
-msgstr "周辺の改修"
+msgstr "屋外の改装"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.BUILD_OUTSIDE_BIOME_DESCRIPTION
 msgctxt ""
@@ -201,7 +201,7 @@ msgctxt ""
 msgid ""
 "Generate 240,000kJ of power without using coal, natural gas, petrol or wood "
 "generators."
-msgstr "石炭、天然ガス、石油、木材発電機を使わずに 240,000kJ 発電する。"
+msgstr "石炭、天然ガス、石油、木材系の発電機を使わずに 240,000kJ 発電する。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.CLEAR_FOW
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.CLEAR_FOW"
@@ -222,12 +222,12 @@ msgstr "名誉博士号"
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.COMPLETED_RESEARCH_DESCRIPTION"
 msgid "Unlock every item in the Research Tree."
-msgstr "研究ツリーのすべての項目をアンロックする。"
+msgstr "研究ツリーにおいて全ての研究を完了する。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.COMPLETED_SKILL_BRANCH
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.COMPLETED_SKILL_BRANCH"
 msgid "To Pay the Bills"
-msgstr "請求書払い"
+msgstr "身を立てるため"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.COMPLETED_SKILL_BRANCH_DESCRIPTION
 msgctxt ""
@@ -235,7 +235,8 @@ msgctxt ""
 "COMPLETED_SKILL_BRANCH_DESCRIPTION"
 msgid ""
 "Use a Duplicant's Skill Points to buy out an entire branch of the Skill Tree."
-msgstr "複製人間のスキルポイントをスキルツリーのすべてに割り当てる。"
+msgstr ""
+"複製人間のスキルポイントを使って、スキルツリーのいずれか1系統を全て習得する。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.COOKED_FOOD
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.COOKED_FOOD"
@@ -258,7 +259,7 @@ msgstr "病み上がり"
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.CURED_DISEASE_DESCRIPTION"
 msgid "Cure a sick Duplicant of disease."
-msgstr "病気の複製人間を治療した。"
+msgstr "病気の複製人間を治療する。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.EAT_MEAT
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.EAT_MEAT"
@@ -274,18 +275,18 @@ msgstr "100サイクルまでに400,000kcal分の動物の肉を複製人間に�
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.EQUIP_N_DUPES
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.EQUIP_N_DUPES"
 msgid "And Nowhere to Go"
-msgstr "行く場所が無い"
+msgstr "なお出かける先は無し"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.EQUIP_N_DUPES_DESCRIPTION
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.EQUIP_N_DUPES_DESCRIPTION"
 msgid "Have {0} Duplicants wear non-default clothing simultaneously."
-msgstr "同時に{0}人の複製人間にデフォルト以外の服を着させる。"
+msgstr "同時に{0}人の複製人間にデフォルト以外の服を着せる。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.EXOSUIT_CYCLES
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.EXOSUIT_CYCLES"
 msgid "Job Suitability"
-msgstr "職業適性"
+msgstr "スーツの似合う仕事"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.EXOSUIT_CYCLES_DESCRIPTION
 msgctxt ""
@@ -294,13 +295,13 @@ msgid ""
 "For {0} cycles in a row, have every Duplicant in the colony complete at "
 "least one chore while wearing an Exosuit."
 msgstr ""
-"連続{0}サイクル、コロニーのすべての複製人間がEXOスーツを着用して最低1つの作業"
-"を完了する。"
+"{0}サイクル以上にわたり、コロニーの全ての複製人間がEXOスーツを着たまま少なく"
+"とも1つの作業を完了する。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.EXPLORE_OIL_BIOME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.EXPLORE_OIL_BIOME"
 msgid "Slick"
-msgstr "つるつる"
+msgstr "油まみれ"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.EXPLORE_OIL_BIOME_DESCRIPTION
 msgctxt ""
@@ -311,7 +312,7 @@ msgstr "オイルバイオームに初めて到達する。"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.GENERATOR_TUNEUP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.GENERATOR_TUNEUP"
 msgid "Finely Tuned Machine"
-msgstr "細かく調整されたマシン"
+msgstr "精密に調整されたマシン"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.GENERATOR_TUNEUP_DESCRIPTION
 msgctxt ""
@@ -328,7 +329,7 @@ msgstr "良い卵"
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.HATCH_A_CRITTER_DESCRIPTION"
 msgid "Hatch a new critter morph from an egg."
-msgstr "卵から動物幼体を孵化させる。"
+msgstr "卵から動物の変種を孵化させる。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.HATCH_REFINEMENT
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.HATCH_REFINEMENT"
@@ -353,7 +354,8 @@ msgid ""
 "Have Auto-Sweepers complete more deliveries to machines than Duplicants over "
 "5 cycles."
 msgstr ""
-"5サイクル以上に渡って、自動掃除機による供給が複製人間による供給を上回る。"
+"5サイクル以上にわたり、自動掃除機による設備への供給が複製人間による供給を上回"
+"る。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.INSPECT_POI
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.INSPECT_POI"
@@ -363,12 +365,12 @@ msgstr "グラビタスの幽霊"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.INSPECT_POI_DESCRIPTION
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.INSPECT_POI_DESCRIPTION"
 msgid "Recover a Database entry by inspecting facility ruins."
-msgstr "ファシリティの残骸を調査することで、データベースの内容を復元する。"
+msgstr "施設の残骸を調査することで、データベースの内容を復元する。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.MASTERPIECE_PAINTING
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.MASTERPIECE_PAINTING"
 msgid "Art Underground"
-msgstr "アート アンダーグラウンド"
+msgstr "アングラ芸術"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.MASTERPIECE_PAINTING_DESCRIPTION
 msgctxt ""
@@ -405,26 +407,25 @@ msgctxt ""
 msgid ""
 "Replace all the Outhouses and Wash Basins in your colony with Lavatories and "
 "Sinks."
-msgstr ""
-"コロニー内の野営トイレと手洗い台をすべて水洗トイレと流し台に置き換える。"
+msgstr "コロニー内の野営トイレと手洗い台を全て水洗トイレと流し台に置き換える。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.REACH_SPACE_ANY_DESTINATION
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.REACH_SPACE_ANY_DESTINATION"
 msgid "Space Race"
-msgstr "宇宙レース"
+msgstr "宇宙開発競争"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.REACH_SPACE_ANY_DESTINATION_DESCRIPTION
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS."
 "REACH_SPACE_ANY_DESTINATION_DESCRIPTION"
 msgid "Launch your first rocket into space."
-msgstr "最初のロケットを宇宙に飛ばす。"
+msgstr "最初のロケットを宇宙に打ち上げる。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.SIXKELVIN_BUILDING
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.SIXKELVIN_BUILDING"
 msgid "Not 0K, But Pretty Cool"
-msgstr "とってもクール"
+msgstr "0Kじゃないけど、かなりクール"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.SIXKELVIN_BUILDING_DESCRIPTION
 msgctxt ""
@@ -435,24 +436,24 @@ msgstr "設備の温度を 6K まで下げる。"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.ARM_PERFORMANCE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.ARM_PERFORMANCE"
 msgid "Auto-Sweepers outperformed dupes for cycles: {0} / {1}"
-msgstr "複製人間以上に機能した自動掃除機: {0} / {1}"
+msgstr "数サイクルにわたり、自動掃除機が複製人間以上に機能した: {0} / {1}"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.ARM_VS_DUPE_FETCHES
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.ARM_VS_DUPE_FETCHES"
 msgid "Deliveries this cycle: Auto-Sweepers: {1} Duplicants: {2}"
-msgstr "このサイクルでの供給量: 自動掃除機:{1}、複製人間:{2}"
+msgstr "このサイクルにおける供給量: 自動掃除機: {1}、複製人間: {2}"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.AUTOMATE_A_BUILDING
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.AUTOMATE_A_BUILDING"
 msgid "Automated a building"
-msgstr "設備の自動化"
+msgstr "設備を自動化した"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.BLOCKED_A_COMET
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.BLOCKED_A_COMET"
 msgid "Blocked a meteor with a Bunker Door"
-msgstr "シェルタードアを使って隕石を防ぐ"
+msgstr "シェルタードアを使って隕石を防いだ"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.BUILING_BEDS
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.BUILING_BEDS"
@@ -462,7 +463,7 @@ msgstr "ベッド数: {0} ({1} 必要)"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.BUILT_A_ROOM
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.BUILT_A_ROOM"
 msgid "Built a {0}."
-msgstr "{0} を建設した。"
+msgstr "{0} を建設した"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.BUILT_N_ROOMS
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.BUILT_N_ROOMS"
@@ -516,7 +517,7 @@ msgstr "カロリー: {0} / {1}"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.CONSUME_ITEM
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.CONSUME_ITEM"
 msgid "Consume something prepared at {0}"
-msgstr "{0} に用意された物を消費"
+msgstr "{0} で調理されたものを消費した"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.CREATE_A_PAINTING
 msgctxt ""
@@ -542,13 +543,14 @@ msgstr "オイルバイオームに到達した"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.EXOSUIT_CYCLES
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.EXOSUIT_CYCLES"
 msgid "All Dupes completed a Exosuit errand for cycles: {0} / {1}"
-msgstr "全ての複製人間が1サイクル中にEXOスーツ作業を完了させた: {0} / {1}"
+msgstr ""
+"数サイクルにわたり、全ての複製人間がEXOスーツ作業を完了させた: {0} / {1}"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.EXOSUIT_THIS_CYCLE
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.EXOSUIT_THIS_CYCLE"
 msgid "Dupes who completed Exosuit errands this cycle: {0} / {1}"
-msgstr "複製人間が1サイクル中にEXOスーツ作業を完了させた: {0} / {1}"
+msgstr "このサイクル中にEXOスーツ作業を完了させた複製人間: {0} / {1}"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.EXPAND_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.EXPAND_TOOLTIP"
@@ -563,12 +565,12 @@ msgstr "サイクル: {0:0.##} / {1:0.##}"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.GENERATE_POWER
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.GENERATE_POWER"
 msgid "Energy generated: {0} / {1}"
-msgstr "生産エネルギー: {0} / {1}"
+msgstr "発電量: {0} / {1}"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.HATCH_A_MORPH
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.HATCH_A_MORPH"
 msgid "Hatched a critter morph"
-msgstr "動物変種を孵化させた"
+msgstr "動物の変種を孵化させた"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.INVESTIGATE_A_POI
 msgctxt ""
@@ -579,12 +581,12 @@ msgstr "遺跡を調査した"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.KELVIN_COOLING
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.KELVIN_COOLING"
 msgid "Coldest building: {0:##0.#}K"
-msgstr "最も冷たい設備: {0:##0.#}K"
+msgstr "最も低温の設備: {0:##0.#}K"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.LAUNCHED_ROCKET
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.LAUNCHED_ROCKET"
 msgid "Launched a Rocket into Space"
-msgstr "ロケットを宇宙に飛ばした"
+msgstr "ロケットを宇宙に打ち上げた"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.LAUNCHED_ROCKET_TO_WORMHOLE
 msgctxt ""
@@ -592,7 +594,7 @@ msgctxt ""
 "LAUNCHED_ROCKET_TO_WORMHOLE"
 msgid ""
 "Sent a Duplicant on a one-way mission to the furthest Starmap destination"
-msgstr "複製人間を星図の最も遠い場所へと送り出す、片道ミッションを実施した"
+msgstr "星図の最も遠い場所へ向けて、複製人間を片道ミッションに送り出した"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.MORALE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.MORALE"
@@ -617,14 +619,15 @@ msgid ""
 "Platform achievements cannot be unlocked because a debug command was used in "
 "this colony. "
 msgstr ""
-"このコロニーではデバッグコマンドが使われたため、実績はアンロックできません。 "
+"このコロニーではデバッグコマンドが使われたため、プラットフォーム上の実績はア"
+"ンロックされません。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.PLATFORM_UNLOCKING_ENABLED
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS."
 "PLATFORM_UNLOCKING_ENABLED"
 msgid "Platform achievements can be unlocked."
-msgstr "実績はアンロックできます。"
+msgstr "プラットフォーム上の実績もアンロックされます。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.POOP_PRODUCTION
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.POOP_PRODUCTION"
@@ -650,22 +653,22 @@ msgstr "残りサイクル: {0} / {1}"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.REVEALED
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.REVEALED"
 msgid "Revealed: {0:0.##}% / {1:0.##}%"
-msgstr "視界確保: {0:0.##}% / {1:0.##}%"
+msgstr "探索済み: {0:0.##}% / {1:0.##}%"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.SKILL_BRANCH
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.SKILL_BRANCH"
 msgid "Unlocked an entire branch of the skill tree"
-msgstr "複製人間のスキルポイントをスキルツリーの枝に全て割り当てる"
+msgstr "スキルツリーの1系統を全て習得した"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.TAME_A_CRITTER
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.TAME_A_CRITTER"
 msgid "Tamed a {0}"
-msgstr "{0}を懐柔した"
+msgstr "{0}を飼い慣らした"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.TECH_RESEARCHED
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.TECH_RESEARCHED"
 msgid "Tech researched: {0} / {1}"
-msgstr "研究済みの技術: {1} {0}"
+msgstr "研究済みの技術: {0} / {1}"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.STATUS.TRAVELED_IN_TUBES
 msgctxt ""
@@ -694,7 +697,7 @@ msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS."
 "SURVIVE_HUNDRED_CYCLES_DESCRIPTION"
 msgid "Reach cycle 100 with at least one living Duplicant."
-msgstr "複製人間が最低一人以上生存した状態で100サイクルを迎える。"
+msgstr "複製人間が少なくとも1人は生存した状態で100サイクルを迎える。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.SURVIVE_ONE_YEAR
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.SURVIVE_ONE_YEAR"
@@ -717,23 +720,23 @@ msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.TAME_BASIC_CRITTERS_DESCRIPTION"
 msgid ""
 "Find and tame one of every critter species in the world. Default morphs only."
-msgstr "惑星に存在するすべての動物を発見、懐柔する。(原種のみ)"
+msgstr "惑星に存在する全ての動物を発見し、飼い慣らす。(原種のみ)"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.TAME_GASSYMOO
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.TAME_GASSYMOO"
 msgid "Moovin' On Up"
-msgstr "上に参ります"
+msgstr "気分はモーモー"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.TAME_GASSYMOO_DESCRIPTION
 msgctxt ""
 "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.TAME_GASSYMOO_DESCRIPTION"
 msgid "Find and tame a Gassy Moo."
-msgstr "ぷすぷす モーを発見、懐柔する。"
+msgstr "ぷすぷす モーを発見し、飼い慣らす。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.TUBE_TRAVEL_DISTANCE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.TUBE_TRAVEL_DISTANCE"
 msgid "Totally Tubular"
-msgstr "完璧なチューブ"
+msgstr "すっかりチューブ状"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.TUBE_TRAVEL_DISTANCE_DESCRIPTION
 msgctxt ""
@@ -745,7 +748,7 @@ msgstr "複製人間が移動チューブで 10,000m 移動する。"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.TWENTY_DUPES
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.TWENTY_DUPES"
 msgid "No Place Like Clone"
-msgstr "同じ場所は無し"
+msgstr "複製に勝るもの無し"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.TWENTY_DUPES_DESCRIPTION
 msgctxt ""
@@ -756,7 +759,7 @@ msgstr "同時に20人以上の複製人間を生存させる。"
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.VARIETY_OF_ROOMS
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.VARIETY_OF_ROOMS"
 msgid "Get a Room"
-msgstr "部屋を作ろう"
+msgstr "部屋でやれ"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.VARIETY_OF_ROOMS_DESCRIPTION
 msgctxt ""
@@ -766,8 +769,8 @@ msgid ""
 "Nature Reserve, a Hospital, a Recreation Room, a Great Hall, a Bedroom, a "
 "Washroom, a Greenhouse and a Stable."
 msgstr ""
-"コロニー内に次の部屋を最低一つ用意する。: 自然保護区、病院、娯楽室、大広間、"
-"寝室、洗面所、温室、厩舎"
+"同一コロニー内に次の部屋を最低1つずつ用意する。: 自然保護区、病院、娯楽室、大"
+"広間、寝室、洗面所、温室、厩舎"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.WINCONDITION_LEAVE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.WINCONDITION_LEAVE"
@@ -780,7 +783,7 @@ msgctxt ""
 msgid ""
 "Ensure your colony's legacy by fulfilling the requirements of the Escape "
 "Imperative."
-msgstr "脱出の使命に必要な要件を満たし、コロニーの遺産を確保する。"
+msgstr "脱出の使命を果たすことで、コロニーが受け継いだものを守り抜く。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.WINCONDITION_STAY
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.WINCONDITION_STAY"
@@ -793,7 +796,7 @@ msgctxt ""
 msgid ""
 "Establish your permanent home by fulfilling the requirements of the Colonize "
 "Imperative."
-msgstr "コロニーの使命に必要な要件を満たし、永住可能な家を設立する。"
+msgstr "入植の使命を果たすことで、恒久的な居住地を確立する。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.NOT_ACHIEVED_EVER
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.NOT_ACHIEVED_EVER"
@@ -808,12 +811,12 @@ msgstr "現在のコロニーはこの取り組みを達成していません"
 #. STRINGS.COLONY_ACHIEVEMENTS.PRE_VICTORY_MESSAGE_BODY
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.PRE_VICTORY_MESSAGE_BODY"
 msgid "IMPERATIVE ACHIEVED: {0}"
-msgstr "使命達成: {0}"
+msgstr "達成した使命: {0}"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.PRE_VICTORY_MESSAGE_HEADER
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.PRE_VICTORY_MESSAGE_HEADER"
 msgid "- ALERT -"
-msgstr "- 警告 -"
+msgstr "- 重大な通知 -"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.THRIVING.DESCRIPTION
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.THRIVING.DESCRIPTION"
@@ -829,11 +832,11 @@ msgid ""
 "\n"
 "This asteroid is our home."
 msgstr ""
-"時間が経つにつれ、その起源を辿ることのできる文明は殆どない。たった一つ大事な"
-"ことがあるとすれば、我々は今ここに居ること、与えられた惑星でベストを尽くすこ"
-"とだ。\n"
+"長い歴史の中で、自分たちの起源を知るという機会に恵まれる文明など、ほとんど存"
+"在しない。ただ重要なのは、我々が今ここにいて、与えられた世界を最大限に活用し"
+"ているということだ。私は誇りを持って言おう…\n"
 "\n"
-"私は誇りをもって、この小惑星が我が家だと言うだろう。"
+"この小惑星が私たちの故郷であると。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.THRIVING.MESSAGE_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.THRIVING.MESSAGE_TITLE"
@@ -862,8 +865,8 @@ msgid ""
 "Build all three sections of a <style=\"KKeyword\">Great Monument</style> to "
 "mark the colony as your home"
 msgstr ""
-"<style=\"KKeyword\">偉大なモニュメント</style>の3つの部位を建設し、コロニーを"
-"我が家だと宣言する"
+"<style=\"KKeyword\">偉大なモニュメント</style>の3つの部位を全て建設し、コロ"
+"ニーを我が家として宣言する"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.THRIVING.REQUIREMENTS.MINIMUM_CYCLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.THRIVING.REQUIREMENTS.MINIMUM_CYCLE"
@@ -906,7 +909,8 @@ msgid ""
 "Few civilizations throughout time have had the privilege of understanding "
 "their origins."
 msgstr ""
-"時間が経つにつれ、起源を辿ることのできる文明は殆ど残っていないでしょう。"
+"長い歴史の中で、自分たちの起源を知るという機会に恵まれる文明など、ほとんど存"
+"在しない。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.THRIVING.VIDEO_TEXT.SECOND
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.THRIVING.VIDEO_TEXT.SECOND"
@@ -914,10 +918,10 @@ msgid ""
 "The only thing that matters is that we are here now, and we make the best of "
 "the world we've been given. I am proud to say..."
 msgstr ""
-"たった一つ大事なことがあるとすれば、我々は今ここに居ること、与えられた世界で"
-"ベストを尽くすことです。"
+"ただ重要なのは、我々が今ここにいて、与えられた世界を最大限に活用しているとい"
+"うことだ。私は誇りを持って言おう…"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.THRIVING.VIDEO_TEXT.THIRD
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.THRIVING.VIDEO_TEXT.THIRD"
 msgid "This asteroid is our home."
-msgstr "誇りをもって、この小惑星が我らの家だと言えます。"
+msgstr "この小惑星が私たちの故郷であると。"


### PR DESCRIPTION
はじめまして。いつも翻訳modにはお世話になっています。実績に関連する翻訳を私なりに見直してみましたので、よければ内容をご検討ください。
以下に主要な変更箇所の幾つかについて解説します。

・Red Light, Green Light
・赤い信号、緑の信号
アメリカにおける子供の遊び（だるまさんがころんだ）が由来と思われます。「赤信号、青信号」としたいところでしたが、実際の色は青ではなく緑なので今の形にしました。

・Some Reservations
・保護区群
ここでいうReservationsは、Nature Reserve（自然保護区）を指していると思われます。

・To Pay the Bills
・身を立てるため
"pay the bills"で「（生活費の）支払いをする」転じて「生計を立てる」という意味になります。スキルポイントを「支払う」ことでスキルを得るゲームシステムに引っ掛けた表現と思われます。複製人間がスキルを獲得してキャリアアップすることから「生計を立てる」と「立身出世する」という両方の意味を持つ「身を立てる」という表現を選びました。

・And Nowhere to Go
・なお出かける先は無し
「せっかく着飾ったのに、お出かけできる場所がない」という残念な意味合いを伝わりやすくしたつもりですが、どうでしょうか。

・Job Suitability
・スーツの似合う仕事
直訳ではまさに職業適性なのですが、EXOスーツと"Suit"abilityを引っ掛けた表現と思われるので、訳としてもスーツという言葉を前面に出し、さらにSuitabilityを「似合う」と強引に曲解して、このような表現としました。

・Slick
・油まみれ
原油バイオームに関連した実績なので、oil slick（油膜の描く虹色の文様）に引っ掛けた表現と思われます。

・Moovin' On Up
・気分はモーモー
「気分は上々」のもじりです。原文にあるGassy "Moo"の駄洒落を残した表現にしました。

・Totally Tubular
・すっかりチューブ状
直訳です。移動チューブを使いすぎて、体型が変わってしまったというジョークだと思います。

・No Place Like Clone
・複製に勝るもの無し
"No place like home（我が家に勝る場所はない）"という定型句のもじりと思われます。

・Get a Room
・部屋でやれ
深読みかもしれませんが、"get a room"には（いちゃいちゃするなら）部屋でやれ、という意味が割と一般的なので取り入れてみました。

そのほか、文言の共通化、ゲーム中の文脈に沿った時制の統一、日本語として自然な表現への改定など、全体的に細かい修正を加えています。
以上よろしくお願いします。