### PR TITLE
Trapped Oilの翻訳を封じこめられた原油に変更

### DIFF
--- a/po/world_traits.po
+++ b/po/world_traits.po
@@ -70,13 +70,13 @@ msgid ""
 "Most of the <style=\"KKeyword\">Oil</style> in this world will need to be "
 "extracted with <link=\"OILWELLCAP\">Oil Well</link>s"
 msgstr ""
-"この小惑星の<style=\"KKeyword\">原油</style>は、通常<link=\"OILWELLCAP\">油井"
-"</link>経由で採取されます"
+"この小惑星の多くの<style=\"KKeyword\">原油</style>は、<link=\"OILWELLCAP\">油井"
+"</link>を使わないと抽出できません"
 
 #. STRINGS.WORLD_TRAITS.DEEP_OIL.NAME
 msgctxt "STRINGS.WORLD_TRAITS.DEEP_OIL.NAME"
 msgid "Trapped Oil"
-msgstr "原油溜まり"
+msgstr "封じこめられた原油"
 
 #. STRINGS.WORLD_TRAITS.DISTRESS_SIGNAL.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.DISTRESS_SIGNAL.DESCRIPTION"

--- a/strings.po
+++ b/strings.po
@@ -90369,13 +90369,13 @@ msgid ""
 "Most of the <style=\"KKeyword\">Oil</style> in this world will need to be "
 "extracted with <link=\"OILWELLCAP\">Oil Well</link>s"
 msgstr ""
-"この小惑星の<style=\"KKeyword\">原油</style>は、通常<link=\"OILWELLCAP\">油井"
-"</link>経由で採取されます"
+"この小惑星の多くの<style=\"KKeyword\">原油</style>は、<link=\"OILWELLCAP\">油井"
+"</link>を使わないと抽出できません"
 
 #. STRINGS.WORLD_TRAITS.DEEP_OIL.NAME
 msgctxt "STRINGS.WORLD_TRAITS.DEEP_OIL.NAME"
 msgid "Trapped Oil"
-msgstr "原油溜まり"
+msgstr "封じこめられた原油"
 
 #. STRINGS.WORLD_TRAITS.DISTRESS_SIGNAL.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.DISTRESS_SIGNAL.DESCRIPTION"


### PR DESCRIPTION
DLC発売記念で翻訳を見て回っています。とりあえず一件。

Trapped Oil特性は原油バイオームを乾いた原油バイオームに変えた上で原油溜まりを追加する特性です。
なので地表に原油が出てきていないという意味で閉じ込められてるのではないかと。