### PR TITLE
ロケット発射UIの文言を刷新

### DIFF
--- a/po/ui.po
+++ b/po/ui.po
@@ -22115,7 +22115,7 @@ msgstr ""
 #. STRINGS.UI.UISIDESCREENS.LAUNCHPADSIDESCREEN.LAUNCH_WARNINGS_BUTTON
 msgctxt "STRINGS.UI.UISIDESCREENS.LAUNCHPADSIDESCREEN.LAUNCH_WARNINGS_BUTTON"
 msgid "ACKNOWLEDGE WARNINGS"
-msgstr "警告受諾"
+msgstr "警告を了解する"
 
 #. STRINGS.UI.UISIDESCREENS.LAUNCHPADSIDESCREEN.LAUNCH_WARNINGS_BUTTON_TOOLTIP
 msgctxt ""
@@ -22125,7 +22125,7 @@ msgid ""
 "------------------\n"
 "<b>Click to ignore warnings and proceed with launch</b>"
 msgstr ""
-"発射チェックリストに事前確認が必要なものがあります！\n"
+"発射チェックリストに万全でない項目があります\n"
 "------------------\n"
 "<b>警告を無視して発射する場合はクリック</b>"
 


### PR DESCRIPTION
ロケットの発射ボタンに表示される文言の意味を分かりやすくしてみました。

ロケットの発射チェックリストは、発射できない原因となっている項目は赤色、発射自体は可能だが万全な状態とはいえない（燃料が満タンでなかったり、先遣隊モジュールに着陸船が積み込まれていなかったり、などの）項目は橙色で表示されます。

赤色の項目は解消されたものの、まだ橙色の項目が残っている場合に、UIの発射ボタンに"ACKNOWLEDGE WARNINGS"が表示されます。
これを押せば、発射ボタンの文言が平常と同じ「発射 秒読み開始」に変わり、普通に発射できる状態になります。

ロケットの状態が万全でないことを（発射チェックリストを通じて）<i>承知</i>した上で、それでも発射を強行する、という流れがあって、その流れの中にある"ACKNOWLEDGE"なので、「了解する」としました。

ふたつ目の文章にある"require attention"は、ロケットの状態は万全でないのに、本当にこのまま発射するの？という注意喚起の意味が込められていると思います。なかなか素直な日本語にならなかったので、思い切って具体的な表現に意訳してみました。あえて英文を尊重するなら「発射チェックリストに留意すべき項目があります」くらいになるでしょうか。

どちらも「状態が万全でないロケットの発射を強行する」というゲーム上の状況を踏まえた上で訳すべき文章だと思います。