### PR TITLE
Research Notesの訳について

### DIFF
--- a/po/ui.po
+++ b/po/ui.po
@@ -2326,7 +2326,7 @@ msgstr "<link=\"PLANTS\">植物</link>"
 #. STRINGS.UI.CODEX.CATEGORYNAMES.RESEARCHNOTES
 msgctxt "STRINGS.UI.CODEX.CATEGORYNAMES.RESEARCHNOTES"
 msgid "<link=\"RESEARCHNOTES\">Research Notes</link>"
-msgstr "<link=\"RESEARCHNOTES\">研究の通知</link>"
+msgstr "<link=\"RESEARCHNOTES\">研究ノート</link>"
 
 #. STRINGS.UI.CODEX.CATEGORYNAMES.ROLES
 msgctxt "STRINGS.UI.CODEX.CATEGORYNAMES.ROLES"


### PR DESCRIPTION
データベースの大項目である"Research Notes"の訳についてです。
中身はどれも、グラビタスの研究者たちによる研究内容の記録やメモなので、Notesはそのまま「ノート」でいいと思います。