### PR TITLE
表記ゆれの統一

### DIFF
--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -960,7 +960,7 @@ msgstr ""
 #. STRINGS.DUPLICANTS.ATTRIBUTES.STRENGTH.NAME
 msgctxt "STRINGS.DUPLICANTS.ATTRIBUTES.STRENGTH.NAME"
 msgid "Strength"
-msgstr "腕力"
+msgstr "筋力"
 
 #. STRINGS.DUPLICANTS.ATTRIBUTES.STRENGTH.SPEEDMODIFIER
 msgctxt "STRINGS.DUPLICANTS.ATTRIBUTES.STRENGTH.SPEEDMODIFIER"
@@ -8368,7 +8368,7 @@ msgstr "<link=\"BASEKEEPING1\">筋力強化</link>"
 #. STRINGS.DUPLICANTS.ROLES.HAULER.DESCRIPTION
 msgctxt "STRINGS.DUPLICANTS.ROLES.HAULER.DESCRIPTION"
 msgid "Minorly increase a Duplicant's strength and carrying capacity"
-msgstr "複製人間の筋力および運搬容量を少し改善します"
+msgstr "複製人間の筋力および運搬重量を少し改善します"
 
 #. STRINGS.DUPLICANTS.ROLES.HAULER.NAME
 msgctxt "STRINGS.DUPLICANTS.ROLES.HAULER.NAME"
@@ -8500,7 +8500,7 @@ msgctxt "STRINGS.DUPLICANTS.ROLES.MATERIALS_MANAGER.DESCRIPTION"
 msgid ""
 "Further increases a Duplicant's strength and carrying capacity for even "
 "swifter deliveries"
-msgstr "複製人間の腕力および運搬容量が更に増加し、配達速度が上昇します"
+msgstr "複製人間の筋力および運搬重量が更に増加し、配達速度が上昇します"
 
 #. STRINGS.DUPLICANTS.ROLES.MATERIALS_MANAGER.NAME
 msgctxt "STRINGS.DUPLICANTS.ROLES.MATERIALS_MANAGER.NAME"
@@ -12210,7 +12210,7 @@ msgstr ""
 #. STRINGS.DUPLICANTS.TRAITS.GRANTSKILL_HAULING1.DESC
 msgctxt "STRINGS.DUPLICANTS.TRAITS.GRANTSKILL_HAULING1.DESC"
 msgid "Minorly increase a Duplicant's strength and carrying capacity"
-msgstr "複製人間の筋力および運搬容量を少し改善します"
+msgstr "複製人間の筋力および運搬重量を少し改善します"
 
 #. STRINGS.DUPLICANTS.TRAITS.GRANTSKILL_HAULING1.NAME
 msgctxt "STRINGS.DUPLICANTS.TRAITS.GRANTSKILL_HAULING1.NAME"
@@ -12236,7 +12236,7 @@ msgctxt "STRINGS.DUPLICANTS.TRAITS.GRANTSKILL_HAULING2.DESC"
 msgid ""
 "Further increases a Duplicant's strength and carrying capacity for even "
 "swifter deliveries"
-msgstr "複製人間の腕力および運搬容量が更に増加し、配達速度が上昇します"
+msgstr "複製人間の筋力および運搬重量が更に増加し、配達速度が上昇します"
 
 #. STRINGS.DUPLICANTS.TRAITS.GRANTSKILL_HAULING2.NAME
 msgctxt "STRINGS.DUPLICANTS.TRAITS.GRANTSKILL_HAULING2.NAME"


### PR DESCRIPTION
複製人間の能力の名称に表記ゆれがありました。
"strength"は「腕力」や「筋力」と訳されていますが、ひとまず腕だけの強さに限定されない「筋力」で統一しました。これはどちらでも構わないと思います。
"carrying capacity"は「運搬重量」や「運搬容量」と訳されていますが、これは単位がkgで表される能力なので「運搬重量」で統一するのがいいと思います。