### PR TITLE
EXOスーツドックのUIを修正

### DIFF
--- a/po/building.po
+++ b/po/building.po
@@ -392,7 +392,7 @@ msgstr "複製人間が切り替えるまで待機します"
 #. STRINGS.BUILDING.STATUSITEMS.CHECKPOINT.LOGIC_CONTROLLED_CLOSED
 msgctxt "STRINGS.BUILDING.STATUSITEMS.CHECKPOINT.LOGIC_CONTROLLED_CLOSED"
 msgid "Clearance: Not Permitted"
-msgstr "クリアランス: 不許可"
+msgstr "検問: 不許可"
 
 #. STRINGS.BUILDING.STATUSITEMS.CHECKPOINT.LOGIC_CONTROLLED_DISCONNECTED
 msgctxt "STRINGS.BUILDING.STATUSITEMS.CHECKPOINT.LOGIC_CONTROLLED_DISCONNECTED"
@@ -402,7 +402,7 @@ msgstr "非自動化"
 #. STRINGS.BUILDING.STATUSITEMS.CHECKPOINT.LOGIC_CONTROLLED_OPEN
 msgctxt "STRINGS.BUILDING.STATUSITEMS.CHECKPOINT.LOGIC_CONTROLLED_OPEN"
 msgid "Clearance: Permitted"
-msgstr "クリアランス: 許可"
+msgstr "検問: 許可"
 
 #. STRINGS.BUILDING.STATUSITEMS.CHECKPOINT.TOOLTIPS.LOGIC_CONTROLLED_CLOSED
 msgctxt ""
@@ -3549,7 +3549,7 @@ msgstr ""
 #. STRINGS.BUILDING.STATUSITEMS.ROCKETPLATFORMCLOSETOCEILING.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.ROCKETPLATFORMCLOSETOCEILING.NAME"
 msgid "Low Clearance: {distance} Tiles"
-msgstr "低クリアランス: ({distance}タイル)"
+msgstr "頭上注意: ({distance}タイル)"
 
 #. STRINGS.BUILDING.STATUSITEMS.ROCKETPLATFORMCLOSETOCEILING.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.ROCKETPLATFORMCLOSETOCEILING.TOOLTIP"
@@ -3787,32 +3787,32 @@ msgstr ""
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.CHARGING.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.CHARGING.NAME"
 msgid "Current Status: Charging Suit"
-msgstr "現在の状態: スーツ充電中"
+msgstr "現在の状態: スーツ充填中"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.CHARGING.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.CHARGING.TOOLTIP"
 msgid "This <style=\"KKeyword\">Suit</style> is docked and refueling"
-msgstr "<style=\"KKeyword\">EXOスーツ</style>はドックで充電中です"
+msgstr "<style=\"KKeyword\">EXOスーツ</style>はドックで充填中です"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.FULLY_CHARGED.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.FULLY_CHARGED.NAME"
 msgid "Current Status: Full Fueled"
-msgstr "現在の状態: 充電済"
+msgstr "現在の状態: 充填済"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.FULLY_CHARGED.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.FULLY_CHARGED.TOOLTIP"
 msgid "This suit is fully refueled and ready for use"
-msgstr "EXOスーツは充電完了し、使用可能です"
+msgstr "EXOスーツは充填完了し、使用可能です"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NEED_CONFIGURATION.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NEED_CONFIGURATION.NAME"
 msgid "Current Status: Needs Configuration"
-msgstr "現在の状態: 要設定"
+msgstr "現在の状態: 設定が必要"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NEED_CONFIGURATION.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NEED_CONFIGURATION.TOOLTIP"
 msgid "Set this dock to store a suit or leave it empty"
-msgstr "ドックにEXOスーツを収納するか、待機状態にします"
+msgstr "このドックへEXOスーツを配達するか、空けておくか選んでください"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NO_COOLANT.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NO_COOLANT.NAME"
@@ -3825,7 +3825,7 @@ msgid ""
 "This dock does not contain enough <link=\"WATER\">Water</link> to refill a "
 "<style=\"KKeyword\">Suit</style>"
 msgstr ""
-"ドックは<style=\"KKeyword\">EXOスーツ</style>に充填するための十分な<link="
+"このドックには<style=\"KKeyword\">EXOスーツ</style>へ充填するための十分な<link="
 "\"WATER\">水</link>がありません"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NO_FUEL.NAME
@@ -3839,7 +3839,7 @@ msgid ""
 "This dock does not contain enough <link=\"PETROLEUM\">Petroleum</link> to "
 "refill a <style=\"KKeyword\">Suit</style>"
 msgstr ""
-"ドックは<style=\"KKeyword\">EXOスーツ</style>に充填するための十分な<link="
+"このドックには<style=\"KKeyword\">EXOスーツ</style>へ充填するための十分な<link="
 "\"PETROLEUM\">石油</link>がありません"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NO_OXYGEN.NAME
@@ -3853,23 +3853,23 @@ msgid ""
 "This dock does not contain enough <link=\"OXYGEN\">Oxygen</link> to refill a "
 "<style=\"KKeyword\">Suit</style>"
 msgstr ""
-"ドックは<style=\"KKeyword\">EXOスーツ</style>に充填するための十分な<link="
+"このドックには<style=\"KKeyword\">EXOスーツ</style>へ充填するための十分な<link="
 "\"OXYGEN\">酸素</link>がありません"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NOT_OPERATIONAL.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NOT_OPERATIONAL.NAME"
 msgid "Current Status: Offline"
-msgstr "現在の状態: オフライン"
+msgstr "現在の状態: 電線未接続"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NOT_OPERATIONAL.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.NOT_OPERATIONAL.TOOLTIP"
 msgid "This dock requires <style=\"KKeyword\">Power</style>"
-msgstr "ドックには<style=\"KKeyword\">電力</style>が必要です"
+msgstr "このドックには<style=\"KKeyword\">電力</style>が必要です"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.READY.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.READY.NAME"
 msgid "Current Status: Empty"
-msgstr "現在の状態: 空"
+msgstr "現在の状態: 空き"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.READY.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.READY.TOOLTIP"
@@ -3877,8 +3877,8 @@ msgid ""
 "This dock is ready to receive a <style=\"KKeyword\">Suit</style>, either by "
 "manual delivery or from a Duplicant returning the suit they're wearing"
 msgstr ""
-"このドックは配達または複製人間が着用している<style=\"KKeyword\">EXOスーツ</"
-"style>の受け入れ準備ができています"
+"このドックは複製人間が脱いだ<style=\"KKeyword\">EXOスーツ</style>を戻せるよ"
+"うに空けてあります"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.SUIT_REQUESTED.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUIT_LOCKER.SUIT_REQUESTED.NAME"
@@ -3904,7 +3904,7 @@ msgstr "ドックは未設定です"
 #. STRINGS.BUILDING.STATUSITEMS.SUITMARKERTRAVERSALANYTIME.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUITMARKERTRAVERSALANYTIME.NAME"
 msgid "Clearance: Always Permitted"
-msgstr "クリアランス: 常時許可"
+msgstr "検問: 常に通過可能"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUITMARKERTRAVERSALANYTIME.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUITMARKERTRAVERSALANYTIME.TOOLTIP"
@@ -3915,8 +3915,8 @@ msgid ""
 "When all available docks are full, Duplicants will unequip their <style="
 "\"KKeyword\">Suits</style> and drop them on the floor"
 msgstr ""
-"スーツ着用の複製人間は<style=\"KKeyword\">EXOスーツ</style>が収納できなくても"
-"通過できます\n"
+"スーツ着用の複製人間は<style=\"KKeyword\">EXOスーツ</style>を戻すための<style="
+"\"KKeyword\">ドック</style>に空きがなくても通過できます\n"
 "------------------\n"
 "ドックに空きがない場合、複製人間は<style=\"KKeyword\">EXOスーツ</style>を床に"
 "脱ぎ捨てます"
@@ -3925,7 +3925,7 @@ msgstr ""
 msgctxt ""
 "STRINGS.BUILDING.STATUSITEMS.SUITMARKERTRAVERSALONLYWHENROOMAVAILABLE.NAME"
 msgid "Clearance: Vacancy Only"
-msgstr "クリアランス: 空きのみ"
+msgstr "検問: ドックに空きが必要"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUITMARKERTRAVERSALONLYWHENROOMAVAILABLE.TOOLTIP
 msgctxt ""
@@ -3934,8 +3934,8 @@ msgid ""
 "Suited Duplicants may pass only if there is room in a <style=\"KKeyword"
 "\">Dock</style> to store their <style=\"KKeyword\">Suit</style>"
 msgstr ""
-"スーツ着用の複製人間は<style=\"KKeyword\">ドック</style>に<style=\"KKeyword"
-"\">EXOスーツ</style>を収容できる場合のみ通過します"
+"スーツ着用の複製人間は<style=\"KKeyword\">EXOスーツ</style>を戻すための<style="
+"\"KKeyword\">ドック</style>に空きがなければ通過できません"
 
 #. STRINGS.BUILDING.STATUSITEMS.SUITMARKERWRONGSIDE.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.SUITMARKERWRONGSIDE.NAME"

--- a/po/buildings.po
+++ b/po/buildings.po
@@ -3581,8 +3581,7 @@ msgid ""
 msgstr ""
 "複製人間から<link=\"DISEASE\">病原菌</link>を除去します。\n"
 "\n"
-"病原菌に覆われた複製人間は指定された方向に通りがかった時に消毒剤を使用しま"
-"す。"
+"指定された方向へ通過する際、病原菌に覆われた複製人間は消毒剤を使用します。"
 
 #. STRINGS.BUILDINGS.PREFABS.HANDSANITIZER.NAME
 msgctxt "STRINGS.BUILDINGS.PREFABS.HANDSANITIZER.NAME"
@@ -4290,8 +4289,8 @@ msgstr ""
 "と<link=\"PETROLEUM\">石油</link>を充填します。\n"
 "スーツの<link=\"DIRTYWATER\">汚染水</link>を排出します。\n"
 "\n"
-"通りがかった複製人間が着替えられるよう、<link=\"JETSUITMARKER\">ジェットスー"
-"ツ チェックポイント</link>の隣に建築してください。"
+"通過する複製人間が着替えられるよう、<link=\"JETSUITMARKER\">ジェットスーツ "
+"チェックポイント</link>の隣に建築してください。"
 
 #. STRINGS.BUILDINGS.PREFABS.JETSUITLOCKER.NAME
 msgctxt "STRINGS.BUILDINGS.PREFABS.JETSUITLOCKER.NAME"
@@ -4677,7 +4676,7 @@ msgstr ""
 "\n"
 "スーツの<link=\"DIRTYWATER\">汚染水</link>を排出します。\n"
 "\n"
-"通りがかった複製人間が着替えられるよう、<link=\"LEADSUITMARKER\">鉛スーツ "
+"通過する複製人間が着替えられるよう、<link=\"LEADSUITMARKER\">鉛スーツ "
 "チェックポイント</link>の隣に建築してください。"
 
 #. STRINGS.BUILDINGS.PREFABS.LEADSUITLOCKER.NAME
@@ -8465,7 +8464,7 @@ msgstr ""
 "<link=\"OXYGENMASK\">酸素マスク</link>を格納し、<link=\"OXYGEN\">酸素</link>"
 "を充填します。\n"
 "\n"
-"通りがかった複製人間が着用できるよう、<link=\"OXYGENMASKMARKER\">酸素マスク"
+"通過する複製人間が着用できるよう、<link=\"OXYGENMASKMARKER\">酸素マスク"
 "チェックポイント</link>の隣に建築してください。"
 
 #. STRINGS.BUILDINGS.PREFABS.OXYGENMASKLOCKER.NAME
@@ -11622,7 +11621,7 @@ msgstr ""
 "\n"
 "スーツの<link=\"DIRTYWATER\">汚染水</link>を排出します。\n"
 "\n"
-"通りがかった複製人間が着替えられるよう、<link=\"SUITMARKER\">アトモスーツ "
+"通過する複製人間が着替えられるよう、<link=\"SUITMARKER\">アトモスーツ "
 "チェックポイント</link>の隣に建築してください。"
 
 #. STRINGS.BUILDINGS.PREFABS.SUITLOCKER.NAME
@@ -12420,8 +12419,7 @@ msgid ""
 msgstr ""
 "複製人間から<link=\"DISEASE\">病原菌</link>を除去します。\n"
 "\n"
-"病原菌に覆われた複製人間は指定された方向に通りがかった時に洗面台を使用しま"
-"す。"
+"指定された方向へ通過する際、病原菌に覆われた複製人間は洗面台を使用します。"
 
 #. STRINGS.BUILDINGS.PREFABS.WASHBASIN.NAME
 msgctxt "STRINGS.BUILDINGS.PREFABS.WASHBASIN.NAME"
@@ -12442,8 +12440,7 @@ msgid ""
 msgstr ""
 "複製人間から<link=\"DISEASE\">病原菌</link>を除去します。\n"
 "\n"
-"病原菌に覆われた複製人間は指定された方向に通りがかった時に流し台を使用しま"
-"す。"
+"指定された方向へ通過する際、病原菌に覆われた複製人間は流し台を使用します。"
 
 #. STRINGS.BUILDINGS.PREFABS.WASHSINK.NAME
 msgctxt "STRINGS.BUILDINGS.PREFABS.WASHSINK.NAME"

--- a/po/misc.po
+++ b/po/misc.po
@@ -1541,12 +1541,12 @@ msgstr "設備の内部構造が破損しています"
 #. STRINGS.MISC.NOTIFICATIONS.SUIT_DROPPED.NAME
 msgctxt "STRINGS.MISC.NOTIFICATIONS.SUIT_DROPPED.NAME"
 msgid "No Docks available"
-msgstr "ドックがありません"
+msgstr "ドックに空きがない"
 
 #. STRINGS.MISC.NOTIFICATIONS.SUIT_DROPPED.TOOLTIP
 msgctxt "STRINGS.MISC.NOTIFICATIONS.SUIT_DROPPED.TOOLTIP"
 msgid "An exosuit was dropped because there were no empty docks available"
-msgstr "EXOスーツドックの空きがないため、EXOスーツは放置されています"
+msgstr "ドックに空きがないため、EXOスーツはその場に脱ぎ捨てられました"
 
 #. STRINGS.MISC.NOTIFICATIONS.SUITS.MESSAGEBODY
 msgctxt "STRINGS.MISC.NOTIFICATIONS.SUITS.MESSAGEBODY"

--- a/po/ui.po
+++ b/po/ui.po
@@ -23848,34 +23848,34 @@ msgstr "スーツ配達指示を取り消します"
 #. STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_DROP_SUIT
 msgctxt "STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_DROP_SUIT"
 msgid "Undock Suit"
-msgstr "EXOスーツ取外し"
+msgstr "スーツを取り外す"
 
 #. STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_DROP_SUIT_NO_SUIT_TOOLTIP
 msgctxt ""
 "STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_DROP_SUIT_NO_SUIT_TOOLTIP"
 msgid "There is no suit in this building to undock"
-msgstr "この設備には取外し可能なスーツがありません"
+msgstr "このドックには取り外し可能なスーツがありません"
 
 #. STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_DROP_SUIT_TOOLTIP
 msgctxt "STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_DROP_SUIT_TOOLTIP"
 msgid "Disconnect this suit, dropping it on the ground"
-msgstr "このスーツとの接続を解除し、床に落とします"
+msgstr "格納されたスーツを取り外して床に落とします"
 
 #. STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_NO_SUIT
 msgctxt "STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_NO_SUIT"
 msgid "Leave Empty"
-msgstr "空き"
+msgstr "空けておく"
 
 #. STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_NO_SUIT_TOOLTIP
 msgctxt "STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_NO_SUIT_TOOLTIP"
 msgid ""
 "The next suited Duplicant to pass by will unequip their suit and dock it here"
-msgstr "次に来るスーツ着用の複製人間はここでスーツを脱ぎドックに収納します"
+msgstr "次に通過するスーツ着用の複製人間は、ここでスーツを脱いでドックに戻します"
 
 #. STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_REQUEST_SUIT
 msgctxt "STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_REQUEST_SUIT"
 msgid "Deliver Suit"
-msgstr "EXOスーツ配達"
+msgstr "スーツを配達する"
 
 #. STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_REQUEST_SUIT_TOOLTIP
 msgctxt "STRINGS.UI.UISIDESCREENS.SUIT_SIDE_SCREEN.CONFIG_REQUEST_SUIT_TOOLTIP"
@@ -25928,7 +25928,7 @@ msgstr "<b>研究ツリー</b> <color=#F44A47>[R]</color>から技術を選ん�
 #. STRINGS.UI.USERMENUACTIONS.SUIT_MARKER_TRAVERSAL.ALWAYS.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.SUIT_MARKER_TRAVERSAL.ALWAYS.NAME"
 msgid "Clearance: Always"
-msgstr "クリアランス: 常時"
+msgstr "検問: なし"
 
 #. STRINGS.UI.USERMENUACTIONS.SUIT_MARKER_TRAVERSAL.ALWAYS.TOOLTIP
 msgctxt "STRINGS.UI.USERMENUACTIONS.SUIT_MARKER_TRAVERSAL.ALWAYS.TOOLTIP"
@@ -25938,16 +25938,16 @@ msgid ""
 "When all available docks are full, Duplicants will unequip their suits and "
 "drop them on the floor"
 msgstr ""
-"スーツ着用の複製人間はスーツが収納できなくても通過できます\n"
+"スーツ着用の複製人間はEXOスーツを戻すためのドックに空きがなくても通過できます\n"
 "------------------\n"
-"ドックに空きがない場合、複製人間はスーツを床に脱ぎ捨てます"
+"ドックに空きがない場合、複製人間はEXOスーツを床に脱ぎ捨てます"
 
 #. STRINGS.UI.USERMENUACTIONS.SUIT_MARKER_TRAVERSAL.ONLY_WHEN_ROOM_AVAILABLE.NAME
 msgctxt ""
 "STRINGS.UI.USERMENUACTIONS.SUIT_MARKER_TRAVERSAL.ONLY_WHEN_ROOM_AVAILABLE."
 "NAME"
 msgid "Clearance: Vacancy"
-msgstr "クリアランス: 空き"
+msgstr "検問: 空きドック必要"
 
 #. STRINGS.UI.USERMENUACTIONS.SUIT_MARKER_TRAVERSAL.ONLY_WHEN_ROOM_AVAILABLE.TOOLTIP
 msgctxt ""
@@ -25957,7 +25957,8 @@ msgid ""
 "Suited Duplicants may only pass if there is an available dock to store their "
 "suit"
 msgstr ""
-"EXOスーツドックに空きがある場合のみ、スーツ着用の複製人間は通過できます"
+"スーツ着用の複製人間はEXOスーツを戻すためのドックに空きがなければ通過できま"
+"せん"
 
 #. STRINGS.UI.USERMENUACTIONS.TAGFILTER.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.TAGFILTER.NAME"
@@ -25977,7 +25978,7 @@ msgstr "{0} を外す"
 #. STRINGS.UI.USERMENUACTIONS.UNEQUIP.TOOLTIP
 msgctxt "STRINGS.UI.USERMENUACTIONS.UNEQUIP.TOOLTIP"
 msgid "Take off and drop this equipment"
-msgstr "この装備を外して置きます"
+msgstr "この装備を脱ぎ捨てます"
 
 #. STRINGS.UI.USERMENUACTIONS.UPROOT.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.UPROOT.NAME"


### PR DESCRIPTION
EXOスーツドックまわりのUIを整理してみました。
実際に遊んでみた上で、システムを理解しやすい表現になるよう努めたつもりです。
用語や表現の統一を優先したため、必ずしも原文どおりになっていないところがあります。

- `充電` → `充填`
スーツにチャージするのは電力ではなく酸素なので。（以前指摘を受けた内容と同様です）
- `クリアランス` → `検問`
直訳では「通関」「（飛行機の）離着陸許可」など。つまり通過してもいいかどうかの確認をする意味になります。
- `This dock is ready to receive a Suit, either by manual delivery or from a Duplicant returning the suit they're wearing`
原文では、複製人間が（着用せずに）手で持って配達してきたスーツも受け入れ可能であるように読めますが、実際は脱いだスーツしか受け取ってくれないので、ここでは原文ではなくゲーム上の挙動に沿った訳にしています。
- `Take off and drop` `unequip and drop`
`脱ぎ捨てる`に統一
- `Leave Empty`→`空けておく`
ドックを作った直後、まだ何の設定もしていないドックに対する指示です。
戻ってきたスーツ着用者が脱いだスーツを受け取れる状態にします。

- `passing by`
`通りがかった`だと少し口語的すぎるかなという気がしたので`通過する`で統一しました。
- `Undock Suit` `Deliver Suit`
ドックを選択すると表示されるUIです。このボタンでドックへ指示を与えるので、より直接的になるよう動詞にしました。
- `dock` `store`
ドックにスーツを取り付ける意味で一般的に使われている単語です。現行訳では`格納する`が定訳になっているようです。ただここでは「チェックポイントを通過する際に、今まで着ていたスーツを脱いでドックに取り付けること」に限って`戻す`という表現にしています。`格納する`では、（手で持って）配達してきたスーツを取り付けるのか、その場で脱いだスーツを取り付けるのか区別がつかないためです。

おまけ
- `low clearance` → `頭上注意`
道路標識なんかで使われている慣用表現（？）のようです。
ロケット発射台の標高が高すぎて、高いロケットを建設すると上空の建設制限に引っかかる場合に表示される警告です。
`clearance`で検索したら引っかかったので、ついでに修正してしまいました。