### PR TITLE
設備の損傷に関する翻訳を修正

### DIFF
--- a/po/building.po
+++ b/po/building.po
@@ -1947,7 +1947,7 @@ msgid ""
 "Limit the output to one Bit, or replace it with <style=\"KKeyword\">Logic "
 "Ribbon</style> to prevent further damage"
 msgstr ""
-"この<style=\"KKeyword\">論理ワイヤー</style>はダメージを受けています\n"
+"この<style=\"KKeyword\">論理ワイヤー</style>は損傷を受けています\n"
 "\n"
 "<style=\"KKeyword\">論理リボン</style>で代替するか、出力を1ビットに制限してく"
 "ださい"
@@ -3020,7 +3020,7 @@ msgstr "損傷: オーバーヒート"
 #. STRINGS.BUILDING.STATUSITEMS.OVERHEATED.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.OVERHEATED.TOOLTIP"
 msgid "This building is taking damage and will break down if not cooled"
-msgstr "この設備はダメージを受けており、冷却しなければ崩壊してしまうでしょう"
+msgstr "この設備は過熱による損傷を受けており、冷却しなければ大破してしまうでしょう"
 
 #. STRINGS.BUILDING.STATUSITEMS.OVERLOADED.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.OVERLOADED.NAME"
@@ -4583,7 +4583,7 @@ msgid ""
 msgstr ""
 "現時点におけるこの電線の<style=\"KKeyword\">電力</style>供給量です\n"
 "\n"
-"電線に負荷をかけすぎると損傷の原因となり、ゆくゆくは破損してしまいます"
+"電線に負荷をかけすぎると損傷の原因となり、ゆくゆくは断線してしまいます"
 
 #. STRINGS.BUILDING.STATUSITEMS.WIRECONNECTED.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.WIRECONNECTED.NAME"

--- a/po/buildings.po
+++ b/po/buildings.po
@@ -16,22 +16,22 @@ msgstr ""
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.NAME
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.NAME"
 msgid "Disable Disinfect"
-msgstr "消毒を無効化"
+msgstr "勝手に消毒させない"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.TOOLTIP"
 msgid "Do not automatically disinfect this building"
-msgstr "この設備を自動で消毒しません"
+msgstr "この設備が汚染されても、指示しない限り複製人間が消毒しないようにします"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.ENABLE_AUTODISINFECT.NAME
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.ENABLE_AUTODISINFECT.NAME"
 msgid "Enable Disinfect"
-msgstr "消毒を有効化"
+msgstr "勝手に消毒させる"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.ENABLE_AUTODISINFECT.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.ENABLE_AUTODISINFECT.TOOLTIP"
 msgid "Automatically disinfect this building when it becomes contaminated"
-msgstr "設備が汚染されると自動的に消毒します"
+msgstr "この設備が汚染されたとき、複製人間が自分の判断で消毒するようにします"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.NO_DISEASE.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.NO_DISEASE.TOOLTIP"
@@ -71,7 +71,7 @@ msgstr ""
 #. STRINGS.BUILDINGS.DAMAGESOURCES.BAD_INPUT_ELEMENT
 msgctxt "STRINGS.BUILDINGS.DAMAGESOURCES.BAD_INPUT_ELEMENT"
 msgid "receiving an incorrect substance"
-msgstr "不正な物質が配送されたため"
+msgstr "扱えない物質を取り込んだため"
 
 #. STRINGS.BUILDINGS.DAMAGESOURCES.BUILDING_OVERHEATED
 msgctxt "STRINGS.BUILDINGS.DAMAGESOURCES.BUILDING_OVERHEATED"
@@ -81,12 +81,12 @@ msgstr "オーバーヒート"
 #. STRINGS.BUILDINGS.DAMAGESOURCES.CIRCUIT_OVERLOADED
 msgctxt "STRINGS.BUILDINGS.DAMAGESOURCES.CIRCUIT_OVERLOADED"
 msgid "an overloaded circuit"
-msgstr "過負荷"
+msgstr "回路の過負荷"
 
 #. STRINGS.BUILDINGS.DAMAGESOURCES.COMET
 msgctxt "STRINGS.BUILDINGS.DAMAGESOURCES.COMET"
 msgid "falling space rocks"
-msgstr "彗星落下中"
+msgstr "彗星の落下"
 
 #. STRINGS.BUILDINGS.DAMAGESOURCES.CONDUIT_CONTENTS_BOILED
 msgctxt "STRINGS.BUILDINGS.DAMAGESOURCES.CONDUIT_CONTENTS_BOILED"
@@ -111,7 +111,7 @@ msgstr "隣接する液体の圧力"
 #. STRINGS.BUILDINGS.DAMAGESOURCES.LOGIC_CIRCUIT_OVERLOADED
 msgctxt "STRINGS.BUILDINGS.DAMAGESOURCES.LOGIC_CIRCUIT_OVERLOADED"
 msgid "an overloaded logic circuit"
-msgstr "論理回路過負荷"
+msgstr "論理回路の過負荷"
 
 #. STRINGS.BUILDINGS.DAMAGESOURCES.MICROMETEORITE
 msgctxt "STRINGS.BUILDINGS.DAMAGESOURCES.MICROMETEORITE"
@@ -121,12 +121,12 @@ msgstr "微小隕石"
 #. STRINGS.BUILDINGS.DAMAGESOURCES.MINION_DESTRUCTION
 msgctxt "STRINGS.BUILDINGS.DAMAGESOURCES.MINION_DESTRUCTION"
 msgid "an angry Duplicant. Rude!"
-msgstr "怒れる複製人間です。なんて野蛮な！"
+msgstr "怒れる複製人間の手によるもの。なんて野蛮な！"
 
 #. STRINGS.BUILDINGS.DAMAGESOURCES.NOTIFICATION_TOOLTIP
 msgctxt "STRINGS.BUILDINGS.DAMAGESOURCES.NOTIFICATION_TOOLTIP"
 msgid "A {0} sustained damage from {1}"
-msgstr "{0}は{1}から継続的にダメージを受けています"
+msgstr "{0}は{1}から損傷を受け続けています"
 
 #. STRINGS.BUILDINGS.DAMAGESOURCES.ROCKET
 msgctxt "STRINGS.BUILDINGS.DAMAGESOURCES.ROCKET"
@@ -6314,7 +6314,7 @@ msgstr ""
 "\n"
 "ハンマーが出す音は設備ごとに異なります。\n"
 "\n"
-"ハンマーによる殴打は設備にダメージを与えません。"
+"ハンマーによる殴打は設備に損傷を与えません。"
 
 #. STRINGS.BUILDINGS.PREFABS.LOGICHAMMER.INPUT_NAME
 msgctxt "STRINGS.BUILDINGS.PREFABS.LOGICHAMMER.INPUT_NAME"
@@ -12813,22 +12813,22 @@ msgstr "<link=\"WOODGASGENERATOR\">薪ストーブ</link>"
 #. STRINGS.BUILDINGS.REPAIRABLE.DISABLE_AUTOREPAIR.NAME
 msgctxt "STRINGS.BUILDINGS.REPAIRABLE.DISABLE_AUTOREPAIR.NAME"
 msgid "Disable Autorepair"
-msgstr "自動修理無効化"
+msgstr "勝手に修理させない"
 
 #. STRINGS.BUILDINGS.REPAIRABLE.DISABLE_AUTOREPAIR.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.REPAIRABLE.DISABLE_AUTOREPAIR.TOOLTIP"
 msgid "Only repair this building when ordered"
-msgstr "指示した場合のみ設備を修理します"
+msgstr "この設備が損傷しても、指示しない限り複製人間が修理しないようにします"
 
 #. STRINGS.BUILDINGS.REPAIRABLE.ENABLE_AUTOREPAIR.NAME
 msgctxt "STRINGS.BUILDINGS.REPAIRABLE.ENABLE_AUTOREPAIR.NAME"
 msgid "Enable Autorepair"
-msgstr "自動修理有効化"
+msgstr "勝手に修理させる"
 
 #. STRINGS.BUILDINGS.REPAIRABLE.ENABLE_AUTOREPAIR.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.REPAIRABLE.ENABLE_AUTOREPAIR.TOOLTIP"
 msgid "Automatically repair this building when damaged"
-msgstr "設備に損傷があると自動的に修理します"
+msgstr "この設備が損傷したとき、複製人間が自分の判断で修理するようにします"
 
 #~ msgctxt "STRINGS.BUILDINGS.PREFABS.SCANNERMODULE.EFFECT"
 #~ msgid "Automatically analyzes adjacent space while on a voyage."

--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -703,8 +703,8 @@ msgid ""
 "A building at Overheat <style=\"KKeyword\">Temperature</style> will take "
 "damage and break down if not cooled"
 msgstr ""
-"オーバーヒート<style=\"KKeyword\">温度</style>に達した設備はダメージを受け始"
-"め、冷却しないと機能停止します"
+"オーバーヒート<style=\"KKeyword\">温度</style>に達した設備は損傷を受け続け、"
+"冷却しないかぎり大破してしまいます"
 
 #. STRINGS.DUPLICANTS.ATTRIBUTES.OVERHEATTEMPERATURE.NAME
 msgctxt "STRINGS.DUPLICANTS.ATTRIBUTES.OVERHEATTEMPERATURE.NAME"

--- a/po/misc.po
+++ b/po/misc.po
@@ -138,12 +138,12 @@ msgstr "複製人間の生命力を高く保つための覚書"
 #. STRINGS.MISC.NOTIFICATIONS.BROKENMACHINE.NAME
 msgctxt "STRINGS.MISC.NOTIFICATIONS.BROKENMACHINE.NAME"
 msgid "Building broken"
-msgstr "設備が大破しました"
+msgstr "設備が大破している"
 
 #. STRINGS.MISC.NOTIFICATIONS.BROKENMACHINE.TOOLTIP
 msgctxt "STRINGS.MISC.NOTIFICATIONS.BROKENMACHINE.TOOLTIP"
 msgid "These buildings have taken significant damage and are nonfunctional:"
-msgstr "これらの設備は大きな被害を受けてしまい、機能しなくなりました:"
+msgstr "これらの設備は著しい損傷を受けたため、機能を停止しています:"
 
 #. STRINGS.MISC.NOTIFICATIONS.BUILDINGOVERHEATED.NAME
 msgctxt "STRINGS.MISC.NOTIFICATIONS.BUILDINGOVERHEATED.NAME"
@@ -153,7 +153,7 @@ msgstr "損傷: オーバーヒート"
 #. STRINGS.MISC.NOTIFICATIONS.BUILDINGOVERHEATED.TOOLTIP
 msgctxt "STRINGS.MISC.NOTIFICATIONS.BUILDINGOVERHEATED.TOOLTIP"
 msgid "Extreme heat is damaging these buildings:"
-msgstr "高熱がこれらの設備に損害を与えています:"
+msgstr "これらの設備は過熱により損傷を受けています:"
 
 #. STRINGS.MISC.NOTIFICATIONS.CIRCUIT_OVERLOADED.NAME
 msgctxt "STRINGS.MISC.NOTIFICATIONS.CIRCUIT_OVERLOADED.NAME"
@@ -1526,7 +1526,7 @@ msgstr "複製人間が幸せで生産的でいるための覚書"
 #. STRINGS.MISC.NOTIFICATIONS.STRUCTURALCOLLAPSE.NAME
 msgctxt "STRINGS.MISC.NOTIFICATIONS.STRUCTURALCOLLAPSE.NAME"
 msgid "Structural collapse"
-msgstr "埋没した設備"
+msgstr "崩壊した設備"
 
 #. STRINGS.MISC.NOTIFICATIONS.STRUCTURALCOLLAPSE.TOOLTIP
 msgctxt "STRINGS.MISC.NOTIFICATIONS.STRUCTURALCOLLAPSE.TOOLTIP"
@@ -1667,12 +1667,12 @@ msgid ""
 "take damage, and if left unattended, they will break down and be unusable "
 "until repaired."
 msgstr ""
-"設備を建築する時は、常に<link=\"HEAT\">オーバーヒート温度</link>に注意しそれ"
-"に応じて建築場所を計画するべきだ。 周囲の温度を低く保ちコロニー内の換気を良く"
-"する事も設備の温度を低く保つのに役立つ。\n"
+"設備を建築する際は常に<link=\"HEAT\">オーバーヒート温度</link>を考慮に入れ、"
+"それに基づいて配置を計画すべきだ。周囲の温度を低く保ち、コロニー内の換気を良"
+"くすることも設備の温度を下げるのに役立つ。\n"
 "\n"
-"もし設備を損傷を受け始めるオーバーヒート温度を超えたまま放って置くと、設備は"
-"壊れて修理するまで使えなくなってしまう。"
+"オーバーヒート温度を超えた設備は損傷を受け始め、そのまま放置すると大破して修"
+"理するまで使えなくなってしまう。"
 
 #. STRINGS.MISC.NOTIFICATIONS.TUTORIAL_OVERHEATING.NAME
 msgctxt "STRINGS.MISC.NOTIFICATIONS.TUTORIAL_OVERHEATING.NAME"
@@ -1682,7 +1682,7 @@ msgstr "チュートリアル: 設備の温度"
 #. STRINGS.MISC.NOTIFICATIONS.TUTORIAL_OVERHEATING.TOOLTIP
 msgctxt "STRINGS.MISC.NOTIFICATIONS.TUTORIAL_OVERHEATING.TOOLTIP"
 msgid "Notes on preventing building from breaking"
-msgstr "設備故障予防の覚書"
+msgstr "設備の大破を予防する覚書"
 
 #. STRINGS.MISC.NOTIFICATIONS.UNREACHABLEITEM.NAME
 msgctxt "STRINGS.MISC.NOTIFICATIONS.UNREACHABLEITEM.NAME"
@@ -2041,7 +2041,7 @@ msgstr "この複製人間は多少の擦り傷と打ち身があります"
 #. STRINGS.MISC.STATUSITEMS.HIT.NAME
 msgctxt "STRINGS.MISC.STATUSITEMS.HIT.NAME"
 msgid "{targetName} took {damageAmount} damage from {attackerName}'s attack!"
-msgstr "{attackerName}の攻撃で{targetName}が{damageAmount}を受けた！"
+msgstr "{attackerName}の攻撃で{targetName}が{damageAmount}の損傷を受けた！"
 
 #. STRINGS.MISC.STATUSITEMS.MARKEDFORCOMPOST.NAME
 msgctxt "STRINGS.MISC.STATUSITEMS.MARKEDFORCOMPOST.NAME"

--- a/po/ui.po
+++ b/po/ui.po
@@ -1337,8 +1337,8 @@ msgid ""
 "Drawing more than the maximum allowed <style=\"KKeyword\">Watts</style> can "
 "result in damage to the circuit"
 msgstr ""
-"最大許容量より多い<style=\"KKeyword\">ワット数</style>を流すと、回路を傷める"
-"原因になります"
+"最大許容量より多い<style=\"KKeyword\">ワット数</style>を流すと、回路が損傷す"
+"る原因になります"
 
 #. STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.MESS_TABLE_SALT
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.MESS_TABLE_SALT"
@@ -9934,62 +9934,62 @@ msgstr "<link=\"HEAT\">冷却効果</link>"
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.CIRCUIT_OVERLOADED
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.CIRCUIT_OVERLOADED"
 msgid "Overload Damage"
-msgstr "過負荷ダメージ"
+msgstr "過負荷による損傷"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.COMET
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.COMET"
 msgid "Meteor Damage"
-msgstr "隕石ダメージ"
+msgstr "隕石による損傷"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.CONDUIT_CONTENTS_BOILED
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.CONDUIT_CONTENTS_BOILED"
 msgid "Heat Damage"
-msgstr "沸騰ダメージ"
+msgstr "沸騰による損傷"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.CONDUIT_CONTENTS_FROZE
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.CONDUIT_CONTENTS_FROZE"
 msgid "Cold Damage"
-msgstr "凍結ダメージ"
+msgstr "凍結による損傷"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.CORROSIVE_ELEMENT
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.CORROSIVE_ELEMENT"
 msgid "Corrosive Element Damage"
-msgstr "腐食元素ダメージ"
+msgstr "腐食元素による損傷"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.LIQUID_PRESSURE
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.LIQUID_PRESSURE"
 msgid "Pressure Damage"
-msgstr "水圧ダメージ"
+msgstr "水圧による損傷"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.LOGIC_CIRCUIT_OVERLOADED
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.LOGIC_CIRCUIT_OVERLOADED"
 msgid "Signal Overload Damage"
-msgstr "シグナル過負荷ダメージ"
+msgstr "シグナル過負荷による損傷"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.MICROMETEORITE
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.MICROMETEORITE"
 msgid "Micrometeorite Damage"
-msgstr "微小隕石ダメージ"
+msgstr "微小隕石による損傷"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.MINION_DESTRUCTION
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.MINION_DESTRUCTION"
 msgid "Tantrum Damage"
-msgstr "八つ当たりダメージ"
+msgstr "八つ当たりによる損傷"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.OVERHEAT
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.OVERHEAT"
 msgid "Overheat Damage"
-msgstr "オーバーヒートダメージ"
+msgstr "オーバーヒートによる損傷"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.ROCKET
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.ROCKET"
 msgid "Rocket Thruster Damage"
-msgstr "ロケット スラスター ダメージ"
+msgstr "ロケット噴射による損傷"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.WRONG_ELEMENT
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DAMAGE_POPS.WRONG_ELEMENT"
 msgid "Wrong Element Damage"
-msgstr "素材誤りダメージ"
+msgstr "素材誤りによる損傷"
 
 #. STRINGS.UI.GAMEOBJECTEFFECTS.DARKNESS
 msgctxt "STRINGS.UI.GAMEOBJECTEFFECTS.DARKNESS"


### PR DESCRIPTION
設備の損傷や破壊に関する訳語を統一しました。

- 設備等が壊れた状態
`damage` → `損傷`（耐久度が減っている状態）
`break down` → `大破`（耐久度がゼロになり、修理するまで機能を停止した**設備の**状態）
`Broken` → `破損`（沸騰や過冷却で壊れた**パイプの**状態）

- 自動修理/自動消毒について
`Enable Autorepair` → `勝手に修理させる`
`Disable Autorepair` → `勝手に修理させない`
`Auto`と表現されてはいますが、設備が **自ら** **自動的に** 直るわけではなく、あくまで **複製人間の手で** **手動的に** 直るわけなので、このような訳にしました。（実際に自動的なのは、設備ではなく複製人間のほうです）
`勝手に`では表現として少し口語的すぎるかとも思い、`自発的に`、`進んで`などの言い方も考えましたが、ここは機能を理解しづらい項目なので、直感的な分かりやすさを優先して`勝手に`にしています。