### PR TITLE
Emptyingの訳を修正

### DIFF
--- a/po/building.po
+++ b/po/building.po
@@ -801,7 +801,7 @@ msgstr "この原子炉から発生する放射線量は減少しています"
 #. STRINGS.BUILDING.STATUSITEMS.DESALINATORNEEDSEMPTYING.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.DESALINATORNEEDSEMPTYING.NAME"
 msgid "Requires Emptying"
-msgstr "排出が必要"
+msgstr "塩空け作業が必要"
 
 #. STRINGS.BUILDING.STATUSITEMS.DESALINATORNEEDSEMPTYING.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.DESALINATORNEEDSEMPTYING.TOOLTIP"
@@ -809,7 +809,8 @@ msgid ""
 "This building needs to be emptied of <link=\"SALT\">Salt</link> to resume "
 "function"
 msgstr ""
-"この設備が機能するためには<link=\"SALT\">塩</link>を排出する必要があります"
+"この設備が稼働を再開するには、溜まった<link=\"SALT\">塩</link>を空にする作業"
+"が必要です"
 
 #. STRINGS.BUILDING.STATUSITEMS.DESTINATIONOUTOFRANGE.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.DESTINATIONOUTOFRANGE.NAME"
@@ -1445,17 +1446,17 @@ msgstr "{Epitaph}"
 #. STRINGS.BUILDING.STATUSITEMS.GRAVEEMPTY.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.GRAVEEMPTY.NAME"
 msgid "Empty"
-msgstr "空"
+msgstr "空っぽ"
 
 #. STRINGS.BUILDING.STATUSITEMS.GRAVEEMPTY.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.GRAVEEMPTY.TOOLTIP"
 msgid "This memorial honors no one."
-msgstr "記念碑には誰も居ません。"
+msgstr "この墓標に弔われた者はいません。"
 
 #. STRINGS.BUILDING.STATUSITEMS.HABITATNEEDSEMPTYING.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.HABITATNEEDSEMPTYING.NAME"
 msgid "Requires Emptying"
-msgstr "排出が必要"
+msgstr "汚染水の汲み出しが必要"
 
 #. STRINGS.BUILDING.STATUSITEMS.HABITATNEEDSEMPTYING.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.HABITATNEEDSEMPTYING.TOOLTIP"
@@ -1466,11 +1467,11 @@ msgid ""
 "<link=\"BOTTLEEMPTIER\">Bottle Emptiers</link> can be used to transport and "
 "dispose of <link=\"DIRTYWATER\">Polluted Water</link> in designated areas"
 msgstr ""
-"この<link=\"ALGAEHABITAT\">テラリウム</link>は<link=\"DIRTYWATER\">汚染水</"
-"link>を空にする必要があります\n"
+"この<link=\"ALGAEHABITAT\">テラリウム</link>は、溜まった<link=\"DIRTYWATER\">"
+"汚染水</link>を汲み出す作業が必要です\n"
 "------------------\n"
-"<link=\"DIRTYWATER\">汚染水</link>の廃棄には<link=\"BOTTLEEMPTIER\">ボトル空"
-"け</link>の使用を検討してください"
+"<link=\"BOTTLEEMPTIER\">ボトル空け</link>を使えば、汲み出した<link="
+"\"DIRTYWATER\">汚染水</link>をその場から片付けることができます"
 
 #. STRINGS.BUILDING.STATUSITEMS.HASGANTRY.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.HASGANTRY.NAME"

--- a/po/building.po
+++ b/po/building.po
@@ -801,7 +801,7 @@ msgstr "この原子炉から発生する放射線量は減少しています"
 #. STRINGS.BUILDING.STATUSITEMS.DESALINATORNEEDSEMPTYING.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.DESALINATORNEEDSEMPTYING.NAME"
 msgid "Requires Emptying"
-msgstr "塩空け作業が必要"
+msgstr "塩抜き作業が必要"
 
 #. STRINGS.BUILDING.STATUSITEMS.DESALINATORNEEDSEMPTYING.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.DESALINATORNEEDSEMPTYING.TOOLTIP"
@@ -809,7 +809,7 @@ msgid ""
 "This building needs to be emptied of <link=\"SALT\">Salt</link> to resume "
 "function"
 msgstr ""
-"この設備が稼働を再開するには、溜まった<link=\"SALT\">塩</link>を空にする作業"
+"この設備が稼働を再開するには、溜まった<link=\"SALT\">塩</link>を抜き取る作業"
 "が必要です"
 
 #. STRINGS.BUILDING.STATUSITEMS.DESTINATIONOUTOFRANGE.NAME

--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -1911,19 +1911,20 @@ msgstr "この複製人間は感情表現する機会が与えられれば、す
 #. STRINGS.DUPLICANTS.CHORES.EMPTYDESALINATOR.NAME
 msgctxt "STRINGS.DUPLICANTS.CHORES.EMPTYDESALINATOR.NAME"
 msgid "Empty Desalinator"
-msgstr "淡水化装置を空にする"
+msgstr "淡水化装置の塩空け"
 
 #. STRINGS.DUPLICANTS.CHORES.EMPTYDESALINATOR.STATUS
 msgctxt "STRINGS.DUPLICANTS.CHORES.EMPTYDESALINATOR.STATUS"
 msgid "Going to clean"
-msgstr "淡水化装置の掃除に向かっている"
+msgstr "塩を空けに向かっている"
 
 #. STRINGS.DUPLICANTS.CHORES.EMPTYDESALINATOR.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.CHORES.EMPTYDESALINATOR.TOOLTIP"
 msgid ""
 "This Duplicant is emptying out the <link=\"DESALINATOR\">Desalinator</link>"
 msgstr ""
-"この複製人間は<link=\"DESALINATOR\">淡水化装置</link>を空にしようとしています"
+"この複製人間は<link=\"DESALINATOR\">淡水化装置</link>に溜まった<link=\"SALT"
+"\">塩</link>を空にしようとしています"
 
 # 格納庫以外にも、農地タイルでこのアクションが使用できた
 #. STRINGS.DUPLICANTS.CHORES.EMPTYSTORAGE.NAME
@@ -1939,7 +1940,7 @@ msgstr "内容物を空けに向かっている"
 #. STRINGS.DUPLICANTS.CHORES.EMPTYSTORAGE.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.CHORES.EMPTYSTORAGE.TOOLTIP"
 msgid "This Duplicant is taking items out of storage"
-msgstr "この複製人間は設備の内容物を空にしようとしています"
+msgstr "この複製人間は設備の内容物を取り除こうとしています"
 
 #. STRINGS.DUPLICANTS.CHORES.ENTOMBED.NAME
 msgctxt "STRINGS.DUPLICANTS.CHORES.ENTOMBED.NAME"

--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -1911,12 +1911,12 @@ msgstr "この複製人間は感情表現する機会が与えられれば、す
 #. STRINGS.DUPLICANTS.CHORES.EMPTYDESALINATOR.NAME
 msgctxt "STRINGS.DUPLICANTS.CHORES.EMPTYDESALINATOR.NAME"
 msgid "Empty Desalinator"
-msgstr "淡水化装置の塩空け"
+msgstr "淡水化装置の塩抜き"
 
 #. STRINGS.DUPLICANTS.CHORES.EMPTYDESALINATOR.STATUS
 msgctxt "STRINGS.DUPLICANTS.CHORES.EMPTYDESALINATOR.STATUS"
 msgid "Going to clean"
-msgstr "塩を空けに向かっている"
+msgstr "塩を抜き取りに向かっている"
 
 #. STRINGS.DUPLICANTS.CHORES.EMPTYDESALINATOR.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.CHORES.EMPTYDESALINATOR.TOOLTIP"
@@ -1924,7 +1924,7 @@ msgid ""
 "This Duplicant is emptying out the <link=\"DESALINATOR\">Desalinator</link>"
 msgstr ""
 "この複製人間は<link=\"DESALINATOR\">淡水化装置</link>に溜まった<link=\"SALT"
-"\">塩</link>を空にしようとしています"
+"\">塩</link>を抜き取ろうとしています"
 
 # 格納庫以外にも、農地タイルでこのアクションが使用できた
 #. STRINGS.DUPLICANTS.CHORES.EMPTYSTORAGE.NAME

--- a/po/ui.po
+++ b/po/ui.po
@@ -25294,12 +25294,12 @@ msgstr "複製人間は巣がいっぱいになると自動で収穫を行いま
 #. STRINGS.UI.USERMENUACTIONS.EMPTYDESALINATOR.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.EMPTYDESALINATOR.NAME"
 msgid "Empty Desalinator"
-msgstr "塩を空けさせる"
+msgstr "塩抜きをさせる"
 
 #. STRINGS.UI.USERMENUACTIONS.EMPTYDESALINATOR.TOOLTIP
 msgctxt "STRINGS.UI.USERMENUACTIONS.EMPTYDESALINATOR.TOOLTIP"
 msgid "Empty salt from this desalinator"
-msgstr "この淡水化装置から塩を取り除いて空にするよう指示します"
+msgstr "この淡水化装置から塩を抜き取って空にするよう指示します"
 
 # 格納庫以外にも、農地タイルでこのアクションが使用できた
 #. STRINGS.UI.USERMENUACTIONS.EMPTYSTORAGE.NAME

--- a/po/ui.po
+++ b/po/ui.po
@@ -25127,12 +25127,12 @@ msgstr "更衣室に服の配達を要求"
 #. STRINGS.UI.USERMENUACTIONS.CLEANTOILET.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.CLEANTOILET.NAME"
 msgid "Clean Toilet"
-msgstr "トイレ清掃"
+msgstr "汲み取りさせる"
 
 #. STRINGS.UI.USERMENUACTIONS.CLEANTOILET.TOOLTIP
 msgctxt "STRINGS.UI.USERMENUACTIONS.CLEANTOILET.TOOLTIP"
 msgid "Empty waste from this toilet"
-msgstr "トイレから汚物を除去します"
+msgstr "このトイレから汚物を汲み出すよう指示します"
 
 #. STRINGS.UI.USERMENUACTIONS.CLEAR.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.CLEAR.NAME"
@@ -25264,7 +25264,7 @@ msgstr "この複製人間が移動可能なエリアを非表示にします"
 #. STRINGS.UI.USERMENUACTIONS.DUMP.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.DUMP.NAME"
 msgid "Empty"
-msgstr "空ける"
+msgstr "床に空けさせる"
 
 #. STRINGS.UI.USERMENUACTIONS.DUMP.NAME_OFF
 msgctxt "STRINGS.UI.USERMENUACTIONS.DUMP.NAME_OFF"
@@ -25274,12 +25274,12 @@ msgstr "空けるのをやめる"
 #. STRINGS.UI.USERMENUACTIONS.DUMP.TOOLTIP
 msgctxt "STRINGS.UI.USERMENUACTIONS.DUMP.TOOLTIP"
 msgid "Dump bottle contents onto the floor"
-msgstr "ボトルの中身を床にぶちまけます"
+msgstr "この容器の中身を床にぶちまけるよう指示します"
 
 #. STRINGS.UI.USERMENUACTIONS.DUMP.TOOLTIP_OFF
 msgctxt "STRINGS.UI.USERMENUACTIONS.DUMP.TOOLTIP_OFF"
 msgid "Cancel this empty order"
-msgstr "搬出指示を取り消します"
+msgstr "この容器の中身を床にぶちまける指示を取り消します"
 
 #. STRINGS.UI.USERMENUACTIONS.EMPTYBEEHIVE.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.EMPTYBEEHIVE.NAME"
@@ -25294,18 +25294,18 @@ msgstr "複製人間は巣がいっぱいになると自動で収穫を行いま
 #. STRINGS.UI.USERMENUACTIONS.EMPTYDESALINATOR.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.EMPTYDESALINATOR.NAME"
 msgid "Empty Desalinator"
-msgstr "淡水化装置を空にする"
+msgstr "塩を空けさせる"
 
 #. STRINGS.UI.USERMENUACTIONS.EMPTYDESALINATOR.TOOLTIP
 msgctxt "STRINGS.UI.USERMENUACTIONS.EMPTYDESALINATOR.TOOLTIP"
 msgid "Empty salt from this desalinator"
-msgstr "淡水化装置から塩を除去します"
+msgstr "この淡水化装置から塩を取り除いて空にするよう指示します"
 
 # 格納庫以外にも、農地タイルでこのアクションが使用できた
 #. STRINGS.UI.USERMENUACTIONS.EMPTYSTORAGE.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.EMPTYSTORAGE.NAME"
 msgid "Empty Storage"
-msgstr "内容物を空ける"
+msgstr "内容物を空けさせる"
 
 #. STRINGS.UI.USERMENUACTIONS.EMPTYSTORAGE.NAME_OFF
 msgctxt "STRINGS.UI.USERMENUACTIONS.EMPTYSTORAGE.NAME_OFF"
@@ -25315,12 +25315,12 @@ msgstr "空けるのをやめる"
 #. STRINGS.UI.USERMENUACTIONS.EMPTYSTORAGE.TOOLTIP
 msgctxt "STRINGS.UI.USERMENUACTIONS.EMPTYSTORAGE.TOOLTIP"
 msgid "Eject all resources from this container"
-msgstr "貯蔵されている、全ての資源を取り出します"
+msgstr "この設備の内容物を全て取り出して空にするよう指示します"
 
 #. STRINGS.UI.USERMENUACTIONS.EMPTYSTORAGE.TOOLTIP_OFF
 msgctxt "STRINGS.UI.USERMENUACTIONS.EMPTYSTORAGE.TOOLTIP_OFF"
 msgid "Cancel this empty order"
-msgstr "搬出指示を取り消します"
+msgstr "この設備の内容物を空ける指示を取り消します"
 
 #. STRINGS.UI.USERMENUACTIONS.ENABLEBUILDING.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.ENABLEBUILDING.NAME"


### PR DESCRIPTION
【Emptying の訳について】
ここで言う `Emptying` は、塩詰まりで稼働停止した`淡水化装置`の`塩`を空にしたり、`テラリウム`に溜まり切った`汚染水`を抜いてボトル詰めしたりする作業のことです。

現行では`排出`や`空にする`など文脈によって訳し分けられていますが、これを何とか統一した表現にできないか苦心した末、どうにか形にできたので提案します。

それぞれ
`淡水化装置`: `塩空け`、`塩を空ける`
`テラリウム`: `汚染水の汲み出し`、`汚染水を汲み出す`
などの表現にしています。

`塩空け`というのは一般的な言い回しではありませんが、塩を排出する作業を簡潔な名詞形にする必要があったため、苦心の末にひねり出した造語です。意味は十分に通じるのではないかと判断しています。

【汎用の文章について】
`This Duplicant is taking items out of storage`
この一文は、設備の`内容物を空ける`指示に応じて作業する複製人間に表示される文章なので、`空にしようとしています`という訳にしていましたが、`テラリウム`の`汚染水`を汲み出す作業に向かう複製人間にも表示されることが判明したため、`取り除こうとしています`と改めました（`空にする`だと汚染水だけでなく全ての内容物を取り出すように読めるため）。

【おまけ】
`This memorial honors no one.`
"empty"でgrepした際に目に付いたので（このリクエストの趣旨から外れるので本当は良くないのですが）ついでに修正してしまいました。
設備としての `Memorial` は`墓標`と訳されていたので、それに合わせました。