### PR TITLE
ゲーム設定画面の訳を修正

### DIFF
--- a/po/ui.po
+++ b/po/ui.po
@@ -6068,7 +6068,7 @@ msgstr "しない"
 #. STRINGS.UI.FRONTEND.COLONY_SAVE_OPTIONS_SCREEN.DESCRIPTION
 msgctxt "STRINGS.UI.FRONTEND.COLONY_SAVE_OPTIONS_SCREEN.DESCRIPTION"
 msgid "Note: These values are configured per save file"
-msgstr "注: この設定値はセーブファイルごとに設定されています"
+msgstr "注: 以下の項目はセーブファイルごとに設定されます"
 
 #. STRINGS.UI.FRONTEND.COLONY_SAVE_OPTIONS_SCREEN.TIMELAPSE_DISABLED_DESCRIPTION
 msgctxt ""
@@ -6511,7 +6511,7 @@ msgctxt ""
 "TOOLTIP"
 msgid ""
 "If checked, content from the <i>Spaced Out!</i> Expansion will be available"
-msgstr "チェックを入れると、<i>Spaced Out!</i>DLCの内容が利用可能になります"
+msgstr "チェックを入れると、<i>Spaced Out !</i> DLC の内容が利用可能になります"
 
 #. STRINGS.UI.FRONTEND.CUSTOMGAMESETTINGSSCREEN.SETTINGS.FASTWORKERSMODE.LEVELS.DISABLED.NAME
 msgctxt ""
@@ -7341,7 +7341,7 @@ msgstr "キー割り当て変更"
 #. STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.DEFAULT_TO_CLOUD_SAVES
 msgctxt "STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.DEFAULT_TO_CLOUD_SAVES"
 msgid "Default to cloud saves"
-msgstr "クラウドセーブに戻す"
+msgstr "標準でクラウド上にセーブ"
 
 #. STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.DEFAULT_TO_CLOUD_SAVES_TOOLTIP
 msgctxt ""
@@ -7350,17 +7350,18 @@ msgid ""
 "When a new colony is created, this controls whether it will be saved into "
 "the cloud saves folder for syncing or not."
 msgstr ""
-"新しくコロニーが生成された時、クラウドセーブに保存する/しないを制御します。"
+"新たに始めるゲームのセーブデータを、クラウド上のフォルダに保存するか、ローカ"
+"ルフォルダに保存するか設定します。保存場所はゲームの開始後にも変更できます。"
 
 #. STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.DISABLED_WARNING
 msgctxt "STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.DISABLED_WARNING"
 msgid "More options available in-game"
-msgstr "ゲーム内で利用可能なその他オプション"
+msgstr "残りの項目はゲーム内でのみ設定できます"
 
 #. STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.EXPANSION1_CONTENT_ENABLED
 msgctxt "STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.EXPANSION1_CONTENT_ENABLED"
 msgid "<i>Spaced Out!</i> Expansion Enabled"
-msgstr "<i>Spaced Out!</i> DLCの有効化"
+msgstr "<i>Spaced Out !</i> DLC の有効化"
 
 #. STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.EXPANSION1_CONTENT_ENABLED_TOOLTIP
 msgctxt ""
@@ -7426,7 +7427,7 @@ msgstr "サンドボックスを有効にする"
 #. STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.SAVE_OPTIONS
 msgctxt "STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.SAVE_OPTIONS"
 msgid "SAVE"
-msgstr "セーブ名"
+msgstr "セーブデータ"
 
 #. STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.TEMPERATURE_UNITS
 msgctxt "STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.TEMPERATURE_UNITS"
@@ -7436,7 +7437,7 @@ msgstr "温度単位"
 #. STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.TITLE
 msgctxt "STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.TITLE"
 msgid "GAME OPTIONS"
-msgstr "設定"
+msgstr "ゲーム設定"
 
 #. STRINGS.UI.FRONTEND.GAME_VERSION
 msgctxt "STRINGS.UI.FRONTEND.GAME_VERSION"
@@ -7577,13 +7578,13 @@ msgid ""
 "You have multiple unbound actions, this may result in difficulty playing the "
 "game. Are you sure you want to continue?"
 msgstr ""
-"割り当てられていないアクションがあり、このことはゲームプレイを難しくするかも"
-"しれません。このままでもよろしいですか？"
+"割り当てられていないアクションが複数あります。これではゲームを遊ぶのに不便を"
+"感じるかもしれません。本当に続けてよろしいですか？"
 
 #. STRINGS.UI.FRONTEND.INPUT_BINDINGS_SCREEN.RESET
 msgctxt "STRINGS.UI.FRONTEND.INPUT_BINDINGS_SCREEN.RESET"
 msgid "Reset"
-msgstr "リセット"
+msgstr "標準に戻す"
 
 #. STRINGS.UI.FRONTEND.INPUT_BINDINGS_SCREEN.TITLE
 msgctxt "STRINGS.UI.FRONTEND.INPUT_BINDINGS_SCREEN.TITLE"
@@ -7593,7 +7594,7 @@ msgstr "キーをカスタマイズ"
 #. STRINGS.UI.FRONTEND.INPUT_BINDINGS_SCREEN.UNBOUND_ACTION
 msgctxt "STRINGS.UI.FRONTEND.INPUT_BINDINGS_SCREEN.UNBOUND_ACTION"
 msgid "{0} is unbound. Are you sure you want to continue?"
-msgstr "{0} は割り当てられていません。このままでもよろしいですか？"
+msgstr "{0} は割り当てられていません。本当に続けてよろしいですか？"
 
 #. STRINGS.UI.FRONTEND.INPUT_BINDINGS_SCREEN.WAITING_FOR_INPUT
 msgctxt "STRINGS.UI.FRONTEND.INPUT_BINDINGS_SCREEN.WAITING_FOR_INPUT"
@@ -9063,7 +9064,7 @@ msgstr "完了"
 #. STRINGS.UI.FRONTEND.OPTIONS_SCREEN.CONTROLS
 msgctxt "STRINGS.UI.FRONTEND.OPTIONS_SCREEN.CONTROLS"
 msgid "Controls"
-msgstr "コントロール"
+msgstr "キー割り当て"
 
 #. STRINGS.UI.FRONTEND.OPTIONS_SCREEN.CREDITS
 msgctxt "STRINGS.UI.FRONTEND.OPTIONS_SCREEN.CREDITS"
@@ -9103,7 +9104,7 @@ msgstr "MOD"
 #. STRINGS.UI.FRONTEND.OPTIONS_SCREEN.RESET_TUTORIAL
 msgctxt "STRINGS.UI.FRONTEND.OPTIONS_SCREEN.RESET_TUTORIAL"
 msgid "Reset Tutorial Messages"
-msgstr "チュートリアルメッセージをリセット"
+msgstr "チュートリアルメッセージを初期化"
 
 #. STRINGS.UI.FRONTEND.OPTIONS_SCREEN.RESET_TUTORIAL_WARNING
 msgctxt "STRINGS.UI.FRONTEND.OPTIONS_SCREEN.RESET_TUTORIAL_WARNING"
@@ -9139,20 +9140,20 @@ msgstr "キャンセル"
 #. STRINGS.UI.FRONTEND.OPTIONS_SCREEN.TOGGLE_SANDBOX_SCREEN.CONFIRM
 msgctxt "STRINGS.UI.FRONTEND.OPTIONS_SCREEN.TOGGLE_SANDBOX_SCREEN.CONFIRM"
 msgid "Enable Sandbox Mode"
-msgstr "サンドボックスを有効にする"
+msgstr "サンドボックスモードを有効にする"
 
 #. STRINGS.UI.FRONTEND.OPTIONS_SCREEN.TOGGLE_SANDBOX_SCREEN.CONFIRM_SAVE_BACKUP
 msgctxt ""
 "STRINGS.UI.FRONTEND.OPTIONS_SCREEN.TOGGLE_SANDBOX_SCREEN.CONFIRM_SAVE_BACKUP"
 msgid "Enable Sandbox Mode, but save a backup first"
-msgstr "サンドボックスモードを有効にする前に、データをバックアップしてください"
+msgstr "サンドボックスモードを有効にする前に、\nバックアップデータをセーブする"
 
 #. STRINGS.UI.FRONTEND.OPTIONS_SCREEN.TOGGLE_SANDBOX_SCREEN.UNLOCK_SANDBOX_WARNING
 msgctxt ""
 "STRINGS.UI.FRONTEND.OPTIONS_SCREEN.TOGGLE_SANDBOX_SCREEN."
 "UNLOCK_SANDBOX_WARNING"
 msgid "Sandbox Mode will be enabled for this save file"
-msgstr "サンドボックスモードはこのセーブファイルで有効になります"
+msgstr "サンドボックスモードを有効にすると、元に戻すことはできません"
 
 #. STRINGS.UI.FRONTEND.OPTIONS_SCREEN.UNITS
 msgctxt "STRINGS.UI.FRONTEND.OPTIONS_SCREEN.UNITS"
@@ -9162,7 +9163,7 @@ msgstr "温度単位"
 #. STRINGS.UI.FRONTEND.OPTIONS_SCREEN.UNLOCK_SANDBOX
 msgctxt "STRINGS.UI.FRONTEND.OPTIONS_SCREEN.UNLOCK_SANDBOX"
 msgid "Unlock Sandbox Mode"
-msgstr "サンドボックスモードを開放する"
+msgstr "サンドボックスモードを解禁する"
 
 #. STRINGS.UI.FRONTEND.OPTIONS_SCREEN.WORLD_GEN
 msgctxt "STRINGS.UI.FRONTEND.OPTIONS_SCREEN.WORLD_GEN"
@@ -9625,8 +9626,8 @@ msgid ""
 "They have been reset to their default settings.\n"
 "\n"
 msgstr ""
-"ゲーム設定をロード中に問題が発生しました。\n"
-"デフォルト設定にリセットされます。\n"
+"ゲーム設定を読み込み中に問題が発生しました。\n"
+"標準の設定に初期化されます。\n"
 "\n"
 
 #. STRINGS.UI.FRONTEND.SUPPORTWARNINGS.SAVE_DIRECTORY_INSUFFICIENT_SPACE
@@ -9720,7 +9721,7 @@ msgid ""
 "Reverting to default language."
 msgstr ""
 "選択された言語パック ({0})が見つかりません。\n"
-"初期設定の言語に戻します。"
+"標準設定の言語に戻します。"
 
 #. STRINGS.UI.FRONTEND.TRANSLATIONS_SCREEN.NO_PACKS
 msgctxt "STRINGS.UI.FRONTEND.TRANSLATIONS_SCREEN.NO_PACKS"

--- a/po/ui.po
+++ b/po/ui.po
@@ -6511,7 +6511,7 @@ msgctxt ""
 "TOOLTIP"
 msgid ""
 "If checked, content from the <i>Spaced Out!</i> Expansion will be available"
-msgstr "チェックを入れると、<i>Spaced Out !</i> DLC の内容が利用可能になります"
+msgstr "チェックを入れると、<i>Spaced Out!</i> DLC の内容が利用可能になります"
 
 #. STRINGS.UI.FRONTEND.CUSTOMGAMESETTINGSSCREEN.SETTINGS.FASTWORKERSMODE.LEVELS.DISABLED.NAME
 msgctxt ""
@@ -7361,14 +7361,14 @@ msgstr "残りの項目はゲーム内でのみ設定できます"
 #. STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.EXPANSION1_CONTENT_ENABLED
 msgctxt "STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.EXPANSION1_CONTENT_ENABLED"
 msgid "<i>Spaced Out!</i> Expansion Enabled"
-msgstr "<i>Spaced Out !</i> DLC の有効化"
+msgstr "<i>Spaced Out!</i> DLC の有効化"
 
 #. STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.EXPANSION1_CONTENT_ENABLED_TOOLTIP
 msgctxt ""
 "STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.EXPANSION1_CONTENT_ENABLED_TOOLTIP"
 msgid ""
 "If checked, content from the <i>Spaced Out!</i> Expansion will be available"
-msgstr "チェックを入れると、<i>Spaced Out!</i>DLCの内容が利用可能になります"
+msgstr "チェックを入れると、<i>Spaced Out!</i> DLC の内容が利用可能になります"
 
 #. STRINGS.UI.FRONTEND.GAME_OPTIONS_SCREEN.EXPANSION1_CONTENT_RESTART_BODY
 msgctxt ""

--- a/po/ui.po
+++ b/po/ui.po
@@ -7578,8 +7578,8 @@ msgid ""
 "You have multiple unbound actions, this may result in difficulty playing the "
 "game. Are you sure you want to continue?"
 msgstr ""
-"割り当てられていないアクションが複数あります。これではゲームを遊ぶのに不便を"
-"感じるかもしれません。本当に続けてよろしいですか？"
+"割り当てられていないアクションが複数あります。これではゲームの操作に不便を感"
+"じるかもしれません。本当に続けてよろしいですか？"
 
 #. STRINGS.UI.FRONTEND.INPUT_BINDINGS_SCREEN.RESET
 msgctxt "STRINGS.UI.FRONTEND.INPUT_BINDINGS_SCREEN.RESET"


### PR DESCRIPTION
ゲーム設定を行う画面で訳の誤りが散見されたため、全体的に見直しをしてみました。

- `default`
主に`標準（設定）`という訳に統一しています。
カタカナの`デフォルト`という表記は個人的に余り好きではない（業界内でしか通用しない専門用語の域を脱していないと感じる）ため、この単語はなるべく文脈に沿った日本語にするよう心がけています。

- `Spaced Out ! DLC`
エクスクラメーションマークの**前**にも半角スペースを挟んでいます。現行訳の中に、ここに半角スペースを挟んでいる例があり、実際の画面で確認してみたところ、半角スペースがないと見た目がかなり窮屈に感じられたため、挟むようにしています。

- `Sandbox Mode will be enabled for this save file`
（**これ以後**）このセーブファイルではサンドボックスモードが有効になります、という含意があると思います。
つまり、いったんサンドボックスモードを有効にすると元には戻せません、という警告文だと解釈しました。
サンドボックスモードを有効にする前にバックアップデータを作る選択肢があることが、その裏付けです。
`this save file` と表記されていますが、既存のセーブデータに影響はありません。サンドボックスモードを有効にした後でセーブしたデータは、読み込み直してもサンドボックスモードは元に戻りませんという意味だと思います。