### PR TITLE
星間貨物の説明文を修正

### DIFF
--- a/po/building.po
+++ b/po/building.po
@@ -3341,7 +3341,7 @@ msgstr "この設備は{x}回の発射ごとに自動で定期メンテナンス
 #. STRINGS.BUILDING.STATUSITEMS.RAILGUNPAYLOADNEEDSEMPTYING.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.RAILGUNPAYLOADNEEDSEMPTYING.NAME"
 msgid "Ready To Unpack"
-msgstr "排出準備完了"
+msgstr "開封準備完了"
 
 #. STRINGS.BUILDING.STATUSITEMS.RAILGUNPAYLOADNEEDSEMPTYING.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.RAILGUNPAYLOADNEEDSEMPTYING.TOOLTIP"
@@ -3351,10 +3351,11 @@ msgid ""
 "It can be marked for unpacking manually, or automatically unpacked on "
 "arrival using a <link=\"RAILGUNPAYLOADOPENER\">Payload Opener</link>"
 msgstr ""
-"この積み荷は目的地に到着し、排出準備ができています\n"
+"この積み荷は目的地に到着し、開封準備ができています\n"
 "\n"
-"排出用にマークするか、<link=\"RAILGUNPAYLOADOPENER\">貨物オープナー</link>を"
-"建てることで自動的に排出できます"
+"<style=\"KKeyword\">内容物を空ける</style>指示をして複製人間にその場で開封さ"
+"せるか、あるいは<link=\"RAILGUNPAYLOADOPENER\">貨物オープナー</link>まで運ん"
+"で自動的に開封させることができます"
 
 #. STRINGS.BUILDING.STATUSITEMS.RATIONBOXCONTENTS.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.RATIONBOXCONTENTS.NAME"


### PR DESCRIPTION
`起動貨物モジュール`で小惑星の地表にばら撒いた`星間貨物`に関する文章を修正しました。
`Unpack(ing)` を`開封`と訳しています。

`星間貨物`は`貨物オープナー`がないと動かすことができないため、（おそらく真空の）地表に中身をぶちまけるしかなくなるため、そのことが分かるように説明を補足しています。