### PR TITLE
ホットキー表示の前後に空白を追加

### DIFF
--- a/po/building.po
+++ b/po/building.po
@@ -318,7 +318,7 @@ msgid ""
 "Press <style=\"KKeyword\">Enable Building</style> <b><color=#F44A4A>[ENTER]</"
 "b></color> to resume use"
 msgstr ""
-"<style=\"KKeyword\">設備有効化</style><b><color=#F44A4A>[ENTER]</b></color>"
+"<style=\"KKeyword\">設備有効化</style> <b><color=#F44A4A>[ENTER]</b></color> "
 "キーで再稼働します"
 
 #. STRINGS.BUILDING.STATUSITEMS.BURNER.BURNING_FUEL.NAME
@@ -465,7 +465,7 @@ msgid ""
 msgstr ""
 "操作には{Skills}スキルが必要です\n"
 "------------------\n"
-"<b>スキルパネル</b><b><color=#F44A4A>[J]</b></color>を開き、複製人間に"
+"<b>スキルパネル</b> <b><color=#F44A4A>[J]</b></color> を開き、複製人間に"
 "{Skills}を習得させるか、他の惑星から適切なスキルを持った複製人間を連れてきま"
 "しょう"
 
@@ -508,7 +508,7 @@ msgid ""
 msgstr ""
 "操作には{Skills}スキルが必要です\n"
 "------------------\n"
-"<b>スキルパネル</b><b><color=#F44A4A>[J]</b></color>を開き、複製人間に"
+"<b>スキルパネル</b> <b><color=#F44A4A>[J]</b></color> を開き、複製人間に"
 "{Skills}を習得させましょう"
 
 #. STRINGS.BUILDING.STATUSITEMS.CONDUITBLOCKED.NAME
@@ -2427,7 +2427,7 @@ msgid ""
 msgstr ""
 "素材はこのコンベア輸送網に積載することができません\n"
 "------------------\n"
-"建築メニューの<b>輸送タブ</b> <b><color=#F44A4A>[7]</b></color>から<style="
+"建築メニューの<b>輸送タブ</b> <b><color=#F44A4A>[7]</b></color> から<style="
 "\"KKeyword\">コンベアローダー</style>を接続してください"
 
 #. STRINGS.BUILDING.STATUSITEMS.NEEDSOLIDOUT.NAME
@@ -2501,8 +2501,8 @@ msgid ""
 "Duplicant or care package.\n"
 "I'll need to select a blueprint:"
 msgstr ""
-"製造ポッド<b><color=#F44A4A>[H]</b></color>は新しい複製人間または補給品の複製"
-"準備が整ったようだ。\n"
+"製造ポッド <b><color=#F44A4A>[H]</b></color> は新しい複製人間または補給品の複"
+"製準備が整ったようだ。\n"
 "設計図を選ぶとしよう:"
 
 #. STRINGS.BUILDING.STATUSITEMS.NEWDUPLICANTSAVAILABLE.TOOLTIP
@@ -2534,8 +2534,8 @@ msgid ""
 "Select an unknown destination from the <b>Starmap</b> <b><color=#F44A4A>[Z]</"
 "b></color> to begin analysis"
 msgstr ""
-"分析を始めるには<b>星図</b> <b><color=#F44A4A>[Z]</b></color>から未知の目的地"
-"を選択してください"
+"分析を始めるには<b>星図</b> <b><color=#F44A4A>[Z]</b></color> から未知の目的"
+"地を選択してください"
 
 #. STRINGS.BUILDING.STATUSITEMS.NOAPPLICABLERESEARCHSELECTED.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.NOAPPLICABLERESEARCHSELECTED.NAME"
@@ -2700,8 +2700,8 @@ msgid ""
 "<b><color=#F44A4A>[R]</b></color> or a Destination in the <b>Starmap</b> "
 "<b><color=#F44A4A>[Z]</b></color>"
 msgstr ""
-"<b>研究ツリー</b> <b><color=#F44A4A>[R}</b></color>から<link=\"TECH\">研究</"
-"link>プロジェクトを選択するか、<b>星図</b> <b><color=#F44A4A>[Z]</b></color>"
+"<b>研究ツリー</b> <b><color=#F44A4A>[R]</b></color> から<link=\"TECH\">研究</"
+"link>プロジェクトを選択するか、<b>星図</b> <b><color=#F44A4A>[Z]</b></color> "
 "から目的地を選択してください"
 
 #. STRINGS.BUILDING.STATUSITEMS.NORESEARCHORDESTINATIONSELECTED.TOOLTIP
@@ -2711,9 +2711,9 @@ msgid ""
 "<b><color=#F44A4A>{Hotkey}</b></color> or a Destination in the <b>Starmap</"
 "b> <b><color=#F44A4A>[Z]</b></color>"
 msgstr ""
-"<b>研究ツリー</b> <b><color=#F44A4A>{Hotkey}</b></color>から<link=\"TECH\">研"
-"究</link>プロジェクトを選択するか、<b>星図</b> <b><color=#F44A4A>[Z]</b></"
-"color>から目的地を選択してください"
+"<b>研究ツリー</b> <b><color=#F44A4A>{Hotkey}</b></color> から<link=\"TECH\">"
+"研究</link>プロジェクトを選択するか、<b>星図</b> <b><color=#F44A4A>[Z]</b></"
+"color> から目的地を選択してください"
 
 #. STRINGS.BUILDING.STATUSITEMS.NORESEARCHSELECTED.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.NORESEARCHSELECTED.NAME"
@@ -2837,7 +2837,7 @@ msgstr ""
 "この設備を完全に稼働させるには<style=\"KKeyword\">部屋</style>に建築してくだ"
 "さい\n"
 "\n"
-"<b>ルームレイヤー</b> <b><color=#F44A4A>[F11]</b></color>から全ての<style="
+"<b>ルームレイヤー</b> <b><color=#F44A4A>[F11]</b></color> から全ての<style="
 "\"KKeyword\">部屋</style>の状態を確認できます"
 
 #. STRINGS.BUILDING.STATUSITEMS.NOTINRECOMMENDEDROOM.NAME
@@ -2855,7 +2855,7 @@ msgid ""
 msgstr ""
 "この設備は{0}内に建築することを推奨します\n"
 "\n"
-"<b>ルームレイヤー</b> <b><color=#F44A4A>[F11]</b></color>から全ての<style="
+"<b>ルームレイヤー</b> <b><color=#F44A4A>[F11]</b></color> から全ての<style="
 "\"KKeyword\">Room</style>の状態を確認できます"
 
 #. STRINGS.BUILDING.STATUSITEMS.NOTINREQUIREDROOM.NAME
@@ -2873,7 +2873,7 @@ msgid ""
 msgstr ""
 "この設備を完全に稼働させるには{0}内に建築してください\n"
 "\n"
-"<b>ルームレイヤー</b> <b><color=#F44A4A>[F11]</b></color>から全ての<style="
+"<b>ルームレイヤー</b> <b><color=#F44A4A>[F11]</b></color> から全ての<style="
 "\"KKeyword\">部屋</style>の状態を確認できます"
 
 #. STRINGS.BUILDING.STATUSITEMS.NOTLINKEDTOHEAD.NAME
@@ -3240,7 +3240,7 @@ msgid ""
 msgstr ""
 "この設備はオフに設定されています\n"
 "再開するには<style=\"KKeyword\">設備有効化</style> "
-"<b><color=#F44A4A>[ENTER]</b></color>してください"
+"<b><color=#F44A4A>[ENTER]</b></color> してください"
 
 #. STRINGS.BUILDING.STATUSITEMS.POWERLOOPDETECTED.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.POWERLOOPDETECTED.NAME"
@@ -4439,7 +4439,7 @@ msgid ""
 msgstr ""
 "この設備が機能するにはRADボルトが必要です\n"
 "------------------\n"
-"<b>放射線レイヤー</b><b><color=#F44A4A>[L-SHIFT + F4]</b></color>を開き、この"
+"<b>放射線レイヤー</b> <b><color=#F44A4A>[L-SHIFT + F4]</b></color> を開き、この"
 "設備の放射線入出力口を確認してください"
 
 #. STRINGS.BUILDING.STATUSITEMS.WAITINGFORREPAIRMATERIALS.LINE_ITEM

--- a/po/ui.po
+++ b/po/ui.po
@@ -168,7 +168,7 @@ msgstr "<link=\"BUILDCATEGORYEQUIPMENT\">端末</link>"
 #. STRINGS.UI.BUILDCATEGORIES.EQUIPMENT.TOOLTIP
 msgctxt "STRINGS.UI.BUILDCATEGORIES.EQUIPMENT.TOOLTIP"
 msgid "Unlock new technologies through the power of science! {Hotkey}"
-msgstr "科学の力で新しい技術を手に入れましょう！{Hotkey}"
+msgstr "科学の力で新しい技術を手に入れましょう！ {Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.FOOD.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.FOOD.NAME"
@@ -199,7 +199,7 @@ msgstr "<link=\"BUILDCATEGORYHEP\">放射線</link>"
 #. STRINGS.UI.BUILDCATEGORIES.HEP.TOOLTIP
 msgctxt "STRINGS.UI.BUILDCATEGORIES.HEP.TOOLTIP"
 msgid "Here's where things get rad. {Hotkey}"
-msgstr "全てが\"RAD\"になります。 {Hotkey}"
+msgstr "全てが\"RAD\"になります。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.HVAC.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.HVAC.NAME"
@@ -259,7 +259,7 @@ msgstr "<link=\"BUILDCATEGORYPOWER\">電力</link>"
 #. STRINGS.UI.BUILDCATEGORIES.POWER.TOOLTIP
 msgctxt "STRINGS.UI.BUILDCATEGORIES.POWER.TOOLTIP"
 msgid "Need to power the colony? Here's how to do it! {Hotkey}"
-msgstr "コロニーに電力が必要ですか？これをどうぞ！{Hotkey}"
+msgstr "コロニーに電力が必要ですか？これをどうぞ！ {Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.REFINING.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.REFINING.NAME"
@@ -11348,7 +11348,7 @@ msgstr "研究"
 #. STRINGS.UI.NEWBUILDCATEGORIES.EQUIPMENT.TOOLTIP
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.EQUIPMENT.TOOLTIP"
 msgid "Unlock new technologies through the power of science! {Hotkey}"
-msgstr "科学の力で新しい技術を手に入れましょう！{Hotkey}"
+msgstr "科学の力で新しい技術を手に入れましょう！ {Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.FARMING.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.FARMING.BUILDMENUTITLE"
@@ -11373,7 +11373,7 @@ msgstr "<link=\"BUILDCATEGORYFOODANDAGRICULTURE\">食糧</link>"
 #. STRINGS.UI.NEWBUILDCATEGORIES.FOODANDAGRICULTURE.TOOLTIP
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.FOODANDAGRICULTURE.TOOLTIP"
 msgid "Keep my Duplicants' spirits high and their bellies full. {Hotkey}"
-msgstr "複製人間の心と胃袋を満たしましょう。 {Hotkey}"
+msgstr "複製人間の心と胃袋を満たしましょう。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.FURNITURE.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.FURNITURE.BUILDMENUTITLE"
@@ -11388,7 +11388,7 @@ msgstr "家具"
 #. STRINGS.UI.NEWBUILDCATEGORIES.FURNITURE.TOOLTIP
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.FURNITURE.TOOLTIP"
 msgid "Amenities to keep my Duplicants happy, comfy and efficient. {Hotkey}"
-msgstr "複製人間が幸せで快適に効率よく生活するためのアメニティです。 {Hotkey}"
+msgstr "複製人間が幸せで快適に効率よく生活するためのアメニティです。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.GENERATORS.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.GENERATORS.BUILDMENUTITLE"
@@ -11594,7 +11594,7 @@ msgstr "配管"
 #. STRINGS.UI.NEWBUILDCATEGORIES.PLUMBINGSTRUCTURES.TOOLTIP
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.PLUMBINGSTRUCTURES.TOOLTIP"
 msgid "Get your water running and the sewage flowing. {Hotkey}"
-msgstr "上水下水の制御をします。 {Hotkey}"
+msgstr "上水下水の制御をします。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.POWERCONTROL.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.POWERCONTROL.BUILDMENUTITLE"
@@ -11678,17 +11678,17 @@ msgstr ""
 #. STRINGS.UI.NEWBUILDCATEGORIES.ROCKETRY.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.ROCKETRY.BUILDMENUTITLE"
 msgid "Rocketry"
-msgstr "ロケット工学"
+msgstr "ロケット"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.ROCKETRY.NAME
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.ROCKETRY.NAME"
 msgid "Rocketry"
-msgstr "ロケット工学"
+msgstr "ロケット"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.ROCKETRY.TOOLTIP
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.ROCKETRY.TOOLTIP"
 msgid "Rocketry {Hotkey}"
-msgstr "ロケット工学{Hotkey}"
+msgstr "ロケット {Hotkey}"
 
 # 格納庫以外にも、農地タイルでこのアクションが使用できた
 #. STRINGS.UI.NEWBUILDCATEGORIES.STORAGE.BUILDMENUTITLE
@@ -14957,7 +14957,7 @@ msgid ""
 "used. {Hotkey}"
 msgstr ""
 "<b>サンドボックスモード</b>を使う前に、オプションメニューからサンドボックス"
-"モードを有効にしてください。 {Hotkey}"
+"モードを有効にしてください。{Hotkey}"
 
 #. STRINGS.UI.SANDBOX_TOGGLE.TOOLTIP_UNLOCKED
 msgctxt "STRINGS.UI.SANDBOX_TOGGLE.TOOLTIP_UNLOCKED"
@@ -15068,7 +15068,7 @@ msgstr "ブラシ"
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.BRUSH.TOOLTIP
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.BRUSH.TOOLTIP"
 msgid "Paint elements into the world simulation {Hotkey}"
-msgstr "シミュレーションへ元素を塗りたくります{Hotkey}"
+msgstr "シミュレーションへ元素を塗りたくります {Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.BRUSH_NOISE_DENSITY.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.BRUSH_NOISE_DENSITY.NAME"
@@ -15108,7 +15108,7 @@ msgstr "がれき掃除"
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.CLEAR_FLOOR.TOOLTIP
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.CLEAR_FLOOR.TOOLTIP"
 msgid "Delete loose items cluttering the floor {Hotkey}"
-msgstr "床に散らばったアイテムを削除します{Hotkey}"
+msgstr "床に散らばったアイテムを削除します {Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.CRITTER.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.CRITTER.NAME"
@@ -15118,7 +15118,7 @@ msgstr "動物除去"
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.CRITTER.TOOLTIP
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.CRITTER.TOOLTIP"
 msgid "Remove Critters! {Hotkey}"
-msgstr "動物を除去します！{Hotkey}"
+msgstr "動物を除去します！ {Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.DESTROY.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.DESTROY.NAME"
@@ -15128,7 +15128,7 @@ msgstr "破壊"
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.DESTROY.TOOLTIP
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.DESTROY.TOOLTIP"
 msgid "Delete everything in the selected cell(s) {Hotkey}"
-msgstr "選択したセル内の全てを破壊します{Hotkey}"
+msgstr "選択したセル内の全てを破壊します {Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.DISEASE.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.DISEASE.NAME"
@@ -15169,7 +15169,7 @@ msgstr "塗りつぶし"
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.FLOOD.TOOLTIP
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.FLOOD.TOOLTIP"
 msgid "Fill a section of the simulation with the chosen element {Hotkey}"
-msgstr "選択した元素で矩形を塗りつぶします{Hotkey}"
+msgstr "選択した元素で矩形を塗りつぶします {Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.FOW.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.FOW.NAME"
@@ -15179,7 +15179,7 @@ msgstr "マップ開示"
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.FOW.TOOLTIP
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.FOW.TOOLTIP"
 msgid "Dispel the Fog of War shrouding the map {Hotkey}"
-msgstr "マップ上のFoW(戦場の霧)を消去します{Hotkey}"
+msgstr "マップ上のFoW(戦場の霧)を消去します {Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.HEATGUN.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.HEATGUN.NAME"
@@ -15189,7 +15189,7 @@ msgstr "ヒートガン"
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.HEATGUN.TOOLTIP
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.HEATGUN.TOOLTIP"
 msgid "Inject thermal energy into the simulation {Hotkey}"
-msgstr "熱エネルギーを注入します{Hotkey}"
+msgstr "熱エネルギーを注入します {Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.INSTANT_BUILD.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.INSTANT_BUILD.NAME"
@@ -15259,7 +15259,7 @@ msgstr "サンプル"
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.SAMPLE.TOOLTIP
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SAMPLE.TOOLTIP"
 msgid "Copy the settings from a cell to use with brush tools {Hotkey}"
-msgstr "ブラシツールで使うために、セルの設定をコピーします{Hotkey}"
+msgstr "ブラシツールで使うために、セルの設定をコピーします {Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPAWN_ENTITY.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPAWN_ENTITY.NAME"
@@ -15274,7 +15274,7 @@ msgstr "生成機"
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPAWNER.TOOLTIP
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPAWNER.TOOLTIP"
 msgid "Spawn critters, food, equipment, and other entities {Hotkey}"
-msgstr "食糧や生物、装備などのモノを生成します{Hotkey}"
+msgstr "食糧や生物、装備などのモノを生成します {Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPRINKLE.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPRINKLE.NAME"
@@ -15284,7 +15284,7 @@ msgstr "ばら撒き"
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPRINKLE.TOOLTIP
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.SPRINKLE.TOOLTIP"
 msgid "Paint elements into the simulation using noise {Hotkey}"
-msgstr "元素をスプレーします{Hotkey}"
+msgstr "元素をスプレーします {Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.STRESS.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.STRESS.NAME"
@@ -15294,7 +15294,7 @@ msgstr "ストレス"
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.STRESS.TOOLTIP
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.STRESS.TOOLTIP"
 msgid "Manage Duplicants' stress levels {Hotkey}"
-msgstr "複製人間のストレスレベルを管理します{Hotkey}"
+msgstr "複製人間のストレスレベルを管理します {Hotkey}"
 
 #. STRINGS.UI.SANDBOXTOOLS.SETTINGS.STRESS_ADDITIVE.NAME
 msgctxt "STRINGS.UI.SANDBOXTOOLS.SETTINGS.STRESS_ADDITIVE.NAME"
@@ -19518,7 +19518,7 @@ msgstr "配管掃除ツール"
 #. STRINGS.UI.TOOLS.EMPTY_PIPE.TOOLTIP
 msgctxt "STRINGS.UI.TOOLS.EMPTY_PIPE.TOOLTIP"
 msgid "Extract pipe contents {Hotkey}"
-msgstr "配管の中身を抽出します{Hotkey}"
+msgstr "配管の中身を抽出します {Hotkey}"
 
 #. STRINGS.UI.TOOLS.FILTER_HOVERCARD_HEADER
 msgctxt "STRINGS.UI.TOOLS.FILTER_HOVERCARD_HEADER"
@@ -20030,7 +20030,7 @@ msgstr ""
 #. STRINGS.UI.TOOLTIPS.ATTACKBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.ATTACKBUTTON"
 msgid "Attack poor, wild critters {Hotkey}"
-msgstr "可哀そうな野生動物を攻撃します{Hotkey}"
+msgstr "可哀そうな野生動物を攻撃します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.BASE_VALUE
 msgctxt "STRINGS.UI.TOOLTIPS.BASE_VALUE"
@@ -20040,27 +20040,27 @@ msgstr "基本値"
 #. STRINGS.UI.TOOLTIPS.CANCELBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.CANCELBUTTON"
 msgid "Cancel errands {Hotkey}"
-msgstr "作業をキャンセルします{Hotkey}"
+msgstr "作業をキャンセルします {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.CANCELDECONSTRUCTIONBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.CANCELDECONSTRUCTIONBUTTON"
 msgid "Cancel queued orders or deconstruct existing buildings {Hotkey}"
-msgstr "指示をキャンセルまたは既存の設備を解体します{Hotkey}"
+msgstr "指示をキャンセルまたは既存の設備を解体します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.CAPTUREBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.CAPTUREBUTTON"
 msgid "Capture critters {Hotkey}"
-msgstr "動物を捕獲します{Hotkey}"
+msgstr "動物を捕獲します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.CLEANUPMAINBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.CLEANUPMAINBUTTON"
 msgid "Mop and sweep messy floors {Hotkey}"
-msgstr "汚れた床を掃除&モップ掛けします{Hotkey}"
+msgstr "汚れた床を掃除&モップ掛けします {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.CLEARBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.CLEARBUTTON"
 msgid "Move debris into storage {Hotkey}"
-msgstr "がれきを格納庫に移動します{Hotkey}"
+msgstr "がれきを格納庫に移動します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.CLOSETOOLTIP
 msgctxt "STRINGS.UI.TOOLTIPS.CLOSETOOLTIP"
@@ -20070,37 +20070,37 @@ msgstr "閉じる"
 #. STRINGS.UI.TOOLTIPS.CONVEYOR_OVERLAY_STRING
 msgctxt "STRINGS.UI.TOOLTIPS.CONVEYOR_OVERLAY_STRING"
 msgid "Displays conveyor transport components {Hotkey}"
-msgstr "コンベアの配送部品を表示します{Hotkey}"
+msgstr "コンベアの配送部品を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.CROPS_OVERLAY_STRING
 msgctxt "STRINGS.UI.TOOLTIPS.CROPS_OVERLAY_STRING"
 msgid "Displays plant growth progress {Hotkey}"
-msgstr "植物の生育状況を表示します{Hotkey}"
+msgstr "植物の生育状況を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.DECONSTRUCTBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.DECONSTRUCTBUTTON"
 msgid "Demolish buildings {Hotkey}"
-msgstr "設備を破壊します{Hotkey}"
+msgstr "設備を破壊します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.DECOROVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.DECOROVERLAYSTRING"
 msgid "Displays areas with Morale-boosting decor values {Hotkey}"
-msgstr "士気を上昇させる装飾値の範囲を表示します{Hotkey}"
+msgstr "士気を上昇させる装飾値の範囲を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.DIGBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.DIGBUTTON"
 msgid "Set dig errands {Hotkey}"
-msgstr "採掘作業を指示します{Hotkey}"
+msgstr "採掘作業を指示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.DISEASEOVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.DISEASEOVERLAYSTRING"
 msgid "Displays areas of disease risk {Hotkey}"
-msgstr "病気リスクのあるエリアを表示します{Hotkey}"
+msgstr "病気リスクのあるエリアを表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.DISINFECTBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.DISINFECTBUTTON"
 msgid "Disinfect buildings {Hotkey}"
-msgstr "設備を消毒します{Hotkey}"
+msgstr "設備を消毒します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.DISMISSMESSAGE
 msgctxt "STRINGS.UI.TOOLTIPS.DISMISSMESSAGE"
@@ -20130,17 +20130,17 @@ msgstr "<link=\"POWER\">電力</link>要求"
 #. STRINGS.UI.TOOLTIPS.GASVENTOVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.GASVENTOVERLAYSTRING"
 msgid "Displays gas pipe system components {Hotkey}"
-msgstr "気体パイプの配管を表示します{Hotkey}"
+msgstr "気体パイプの配管を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.HARVESTBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.HARVESTBUTTON"
 msgid "Harvest plants {Hotkey}"
-msgstr "植物を収穫します{Hotkey}"
+msgstr "植物を収穫します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.HEATFLOWOVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.HEATFLOWOVERLAYSTRING"
 msgid "Displays comfortable temperatures for Duplicants {Hotkey}"
-msgstr "複製人間が快適に感じる温度帯のエリアを表示します{Hotkey}"
+msgstr "複製人間が快適に感じる温度帯のエリアを表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.HELP_BUILDLOCATION_ATTACHPOINT
 msgctxt "STRINGS.UI.TOOLTIPS.HELP_BUILDLOCATION_ATTACHPOINT"
@@ -20330,22 +20330,22 @@ msgstr "各セルごとの熱エネルギーを表示します"
 #. STRINGS.UI.TOOLTIPS.LIGHTSOVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.LIGHTSOVERLAYSTRING"
 msgid "Displays the visibility radius of light sources {Hotkey}"
-msgstr "光源の可視範囲を表示します{Hotkey}"
+msgstr "光源の可視範囲を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.LIQUIDVENTOVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.LIQUIDVENTOVERLAYSTRING"
 msgid "Displays liquid pipe system components {Hotkey}"
-msgstr "液体パイプの配管を表示します{Hotkey}"
+msgstr "液体パイプの配管を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.LOGICOVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.LOGICOVERLAYSTRING"
 msgid "Displays automation grid components {Hotkey}"
-msgstr "自動化グリッドの部品を表示します{Hotkey}"
+msgstr "自動化グリッドの部品を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_CODEX
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_CODEX"
 msgid "Browse entries in my Database {Hotkey}"
-msgstr "データベースを参照します{Hotkey}"
+msgstr "データベースを参照します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_CONSUMABLES
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_CONSUMABLES"
@@ -20355,7 +20355,7 @@ msgstr "複製人間の食事と薬の管理をします {Hotkey}"
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_DAILYREPORT
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_DAILYREPORT"
 msgid "View each cycle's Colony Report {Hotkey}"
-msgstr "コロニーのサイクル別のレポートを見ます{Hotkey}"
+msgstr "コロニーのサイクル別のレポートを見ます {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_JOBS
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_JOBS"
@@ -20366,7 +20366,7 @@ msgid ""
 "i> the <style=\"KKeyword\">Building Priorities</style> set by the "
 "<b>Priority Tool</b> <b><color=#F44A4A>[P]</b></color>"
 msgstr ""
-"複製人間の作業種別の優先度を管理します{Hotkey}\n"
+"複製人間の作業種別の優先度を管理します {Hotkey}\n"
 "------------------\n"
 "<style=\"KKeyword\">複製人間の優先度</style>は<b>優先度ツール</b> "
 "<b><color=#F44A4A>[P]</b></color>で<style=\"KKeyword\">設備別の優先度</style>"
@@ -20375,7 +20375,7 @@ msgstr ""
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_PAUSEMENU
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_PAUSEMENU"
 msgid "Open the game menu {Hotkey}"
-msgstr "ゲームメニューを開きます{Hotkey}"
+msgstr "ゲームメニューを開きます {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_REQUIRES_RESEARCH
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_REQUIRES_RESEARCH"
@@ -20420,32 +20420,32 @@ msgstr ""
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_RESEARCH
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_RESEARCH"
 msgid "View the Research Tree {Hotkey}"
-msgstr "研究ツリーを見ます{Hotkey}"
+msgstr "研究ツリーを見ます {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_RESOURCES
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_RESOURCES"
 msgid "Open the resource management screen {Hotkey}"
-msgstr "資源管理画面を開きます{Hotkey}"
+msgstr "資源管理画面を開きます {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_SCHEDULE
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_SCHEDULE"
 msgid "Adjust the colony's time usage {Hotkey}"
-msgstr "コロニーのスケジュールを調整します{Hotkey}"
+msgstr "コロニーのスケジュールを調整します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_SKILLS
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_SKILLS"
 msgid "Manage Duplicants' Skill assignments {Hotkey}"
-msgstr "複製人間のスキル割り当てを管理します{Hotkey}"
+msgstr "複製人間のスキル割り当てを管理します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_STARMAP
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_STARMAP"
 msgid "Manage astronaut rocket missions {Hotkey}"
-msgstr "宇宙飛行士のロケットミッションを管理します{Hotkey}"
+msgstr "宇宙飛行士のロケットミッションを管理します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_VITALS
 msgctxt "STRINGS.UI.TOOLTIPS.MANAGEMENTMENU_VITALS"
 msgid "View my Duplicants' vitals {Hotkey}"
-msgstr "複製人間の健康状態を見ます{Hotkey}"
+msgstr "複製人間の健康状態を見ます {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.MATIERIAL_MOD
 msgctxt "STRINGS.UI.TOOLTIPS.MATIERIAL_MOD"
@@ -20495,7 +20495,7 @@ msgstr "病気の複製人間: {0}"
 #. STRINGS.UI.TOOLTIPS.MOPBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.MOPBUTTON"
 msgid "Mop liquid spills {Hotkey}"
-msgstr "こぼれた液体をモップ掛けします{Hotkey}"
+msgstr "こぼれた液体をモップ掛けします {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.NEXTMESSAGESTOOLTIP
 msgctxt "STRINGS.UI.TOOLTIPS.NEXTMESSAGESTOOLTIP"
@@ -20510,7 +20510,7 @@ msgstr "データベースの項目がありません"
 #. STRINGS.UI.TOOLTIPS.NOISE_POLLUTION_OVERLAY_STRING
 msgctxt "STRINGS.UI.TOOLTIPS.NOISE_POLLUTION_OVERLAY_STRING"
 msgid "Displays ambient noise levels {Hotkey}"
-msgstr "大気中の騒音レベルを表示します{Hotkey}"
+msgstr "大気中の騒音レベルを表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.NOMATERIAL
 msgctxt "STRINGS.UI.TOOLTIPS.NOMATERIAL"
@@ -20525,12 +20525,12 @@ msgstr "データベースの全ての項目を参照します"
 #. STRINGS.UI.TOOLTIPS.OXYGENOVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.OXYGENOVERLAYSTRING"
 msgid "Displays ambient oxygen density {Hotkey}"
-msgstr "大気中の酸素濃度を表示します{Hotkey}"
+msgstr "大気中の酸素濃度を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.PAUSE
 msgctxt "STRINGS.UI.TOOLTIPS.PAUSE"
 msgid "Pause {Hotkey}"
-msgstr "一時停止{Hotkey}"
+msgstr "一時停止 {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.PAUSEBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.PAUSEBUTTON"
@@ -20545,12 +20545,12 @@ msgstr "開始"
 #. STRINGS.UI.TOOLTIPS.POWEROVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.POWEROVERLAYSTRING"
 msgid "Displays power grid components {Hotkey}"
-msgstr "コロニーの配電状況を表示します{Hotkey}"
+msgstr "コロニーの配電状況を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.PRIORITIESOVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.PRIORITIESOVERLAYSTRING"
 msgid "Displays work priority values {Hotkey}"
-msgstr "作業の優先度を表示します{Hotkey}"
+msgstr "作業の優先度を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.PRIORITIZEBUTTON
 msgctxt "STRINGS.UI.TOOLTIPS.PRIORITIZEBUTTON"
@@ -20575,7 +20575,7 @@ msgstr ""
 #. STRINGS.UI.TOOLTIPS.RADIATIONOVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.RADIATIONOVERLAYSTRING"
 msgid "Displays radiation levels {Hotkey}"
-msgstr "放射線レベルを表示します{Hotkey}"
+msgstr "放射線レベルを表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.RANDOMIZENAME
 msgctxt "STRINGS.UI.TOOLTIPS.RANDOMIZENAME"
@@ -20621,7 +20621,7 @@ msgstr "非常警報を切り替える"
 #. STRINGS.UI.TOOLTIPS.ROOMSOVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.ROOMSOVERLAYSTRING"
 msgid "Displays special purpose rooms and bonuses {Hotkey}"
-msgstr "特定の用途に特化した部屋とそのボーナスを表示します{Hotkey}"
+msgstr "特定の用途に特化した部屋とそのボーナスを表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.SELECTAMATERIAL
 msgctxt "STRINGS.UI.TOOLTIPS.SELECTAMATERIAL"
@@ -20678,17 +20678,17 @@ msgstr "ストレスパネルは複製人間の心理状態に影響を及ぼす
 #. STRINGS.UI.TOOLTIPS.SUITOVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.SUITOVERLAYSTRING"
 msgid "Displays Exosuits and related buildings {Hotkey}"
-msgstr "EXOスーツおよび関連設備を表示します{Hotkey}"
+msgstr "EXOスーツおよび関連設備を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.TEMPERATUREOVERLAYSTRING
 msgctxt "STRINGS.UI.TOOLTIPS.TEMPERATUREOVERLAYSTRING"
 msgid "Displays ambient temperature {Hotkey}"
-msgstr "大気温度を表示します{Hotkey}"
+msgstr "大気温度を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.TILEMODE_OVERLAY_STRING
 msgctxt "STRINGS.UI.TOOLTIPS.TILEMODE_OVERLAY_STRING"
 msgid "Displays material information {Hotkey}"
-msgstr "素材の情報を表示します{Hotkey}"
+msgstr "素材の情報を表示します {Hotkey}"
 
 #. STRINGS.UI.TOOLTIPS.UNPAUSE
 msgctxt "STRINGS.UI.TOOLTIPS.UNPAUSE"
@@ -25191,7 +25191,7 @@ msgctxt "STRINGS.UI.USERMENUACTIONS.COPY_BUILDING_SETTINGS.TOOLTIP"
 msgid ""
 "Apply the settings and priorities of this building to other buildings of the "
 "same type {Hotkey}"
-msgstr "この設備の設定と優先度を他の同じタイプの設備にコピーします{Hotkey}"
+msgstr "この設備の設定と優先度を他の同じタイプの設備にコピーします {Hotkey}"
 
 #. STRINGS.UI.USERMENUACTIONS.DECONSTRUCT.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.DECONSTRUCT.NAME"
@@ -25346,14 +25346,14 @@ msgid ""
 "------------------\n"
 "Disabled buildings consume no energy or resources"
 msgstr ""
-"この設備の使用を停止します{Hotkey}\n"
+"この設備の使用を停止します {Hotkey}\n"
 "------------------\n"
 "停止中の設備は電力や資源を消費しません"
 
 #. STRINGS.UI.USERMENUACTIONS.ENABLEBUILDING.TOOLTIP_OFF
 msgctxt "STRINGS.UI.USERMENUACTIONS.ENABLEBUILDING.TOOLTIP_OFF"
 msgid "Resume the use of this building {Hotkey}"
-msgstr "この設備の使用を再開します{Hotkey}"
+msgstr "この設備の使用を再開します {Hotkey}"
 
 #. STRINGS.UI.USERMENUACTIONS.FOLLOWCAM.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.FOLLOWCAM.NAME"


### PR DESCRIPTION
ホットキー（ショートカットキー）表示の前後に、半角スペースがあったりなかったりしたので、必ず半角スペースが置かれるよう統一しました。
例外的に、句読点の直後だけは半角スペースを抜いています。実際に画面を見たとき、空白がなくても十分に間隔が空いているように感じたためです。