### PR TITLE
核廃棄物の三相を区別

### DIFF
--- a/po/elements.po
+++ b/po/elements.po
@@ -723,8 +723,8 @@ msgid ""
 "\">Radioactive Contaminants</link>. Formed in a <link=\"NUCLEARREACTOR"
 "\">Reactor meltdown</link>."
 msgstr ""
-"<link=\"RADIATION\">放射性汚染物質</link>で満たされた極めて毒性の高い液体で"
-"す。<link=\"NUCLEARREACTOR\">炉心溶融</link>時に現れます。"
+"死の灰は<link=\"RADIATION\">放射性汚染物質</link>を多く含んだ極めて毒性の高い"
+"気体です。<link=\"NUCLEARREACTOR\">炉心溶融</link>時に現れます。"
 
 #. STRINGS.ELEMENTS.FALLOUT.NAME
 msgctxt "STRINGS.ELEMENTS.FALLOUT.NAME"
@@ -1789,13 +1789,13 @@ msgid ""
 "Highly toxic liquid full of <link=\"RADIATION\">Radioactive Contaminants</"
 "link>. Formed in a <link=\"NUCLEARREACTOR\">Reactor meltdown</link>."
 msgstr ""
-"<link=\"RADIATION\">放射性汚染物質</link>で満たされた極めて毒性の高い液体で"
-"す。<link=\"NUCLEARREACTOR\">炉心溶融</link>時に現れます。"
+"核廃液は<link=\"RADIATION\">放射性汚染物質</link>を多く含んだ極めて毒性の高い"
+"液体です。<link=\"NUCLEARREACTOR\">炉心溶融</link>時に現れます。"
 
 #. STRINGS.ELEMENTS.NUCLEARWASTE.NAME
 msgctxt "STRINGS.ELEMENTS.NUCLEARWASTE.NAME"
 msgid "<link=\"NUCLEARWASTE\">Nuclear Waste</link>"
-msgstr "<link=\"NUCLEARWASTE\">核廃棄物</link>"
+msgstr "<link=\"NUCLEARWASTE\">核廃液</link>"
 
 #. STRINGS.ELEMENTS.OBSIDIAN.DESC
 msgctxt "STRINGS.ELEMENTS.OBSIDIAN.DESC"
@@ -2363,8 +2363,8 @@ msgid ""
 "Highly toxic liquid full of <link=\"RADIATION\">Radioactive Contaminants</"
 "link>. Formed in a <link=\"NUCLEARREACTOR\">Reactor meltdown</link>."
 msgstr ""
-"<link=\"RADIATION\">放射性汚染物質</link>で満たされた極めて毒性の高い液体で"
-"す。<link=\"NUCLEARREACTOR\">炉心溶融</link>時に現れます。"
+"核廃棄物は<link=\"RADIATION\">放射性汚染物質</link>を多く含んだ極めて毒性の高"
+"い固体です。<link=\"NUCLEARREACTOR\">炉心溶融</link>時に現れます。"
 
 #. STRINGS.ELEMENTS.SOLIDNUCLEARWASTE.NAME
 msgctxt "STRINGS.ELEMENTS.SOLIDNUCLEARWASTE.NAME"


### PR DESCRIPTION
原文に誤りがある（`Solid Nuclear Waste` の説明が`液体`になっている）ようなので、修正しました。
原文に従って、気体・液体・固体でそれぞれ名称が異なるようにしました。
ぐぐっても`核廃液`という用例はあまり存在しませんでしたが（「放射性液体廃棄物」「放射性廃液」などの用例はありました）、ほかに良い表現もなかったため割り切りました。