### PR TITLE
データベースの項目名を修正

### DIFF
--- a/po/ui.po
+++ b/po/ui.po
@@ -2320,7 +2320,7 @@ msgstr "<link=\"MISCELLANEOUSITEMS\">アイテム</link>"
 #. STRINGS.UI.CODEX.CATEGORYNAMES.MISCELLANEOUSTIPS
 msgctxt "STRINGS.UI.CODEX.CATEGORYNAMES.MISCELLANEOUSTIPS"
 msgid "<link=\"MISCELLANEOUSTIPS\">Tips</link>"
-msgstr "<link=\"MISCELLANEOUSTIPS\">Tips</link>"
+msgstr "<link=\"MISCELLANEOUSTIPS\">チュートリアル</link>"
 
 #. STRINGS.UI.CODEX.CATEGORYNAMES.MYLOG
 msgctxt "STRINGS.UI.CODEX.CATEGORYNAMES.MYLOG"
@@ -2330,7 +2330,7 @@ msgstr "<link=\"MYLOG\">私的記録</link>"
 #. STRINGS.UI.CODEX.CATEGORYNAMES.NOTICES
 msgctxt "STRINGS.UI.CODEX.CATEGORYNAMES.NOTICES"
 msgid "<link=\"NOTICES\">Notices</link>"
-msgstr "<link=\"NOTICES\">通知</link>"
+msgstr "<link=\"NOTICES\">掲示</link>"
 
 #. STRINGS.UI.CODEX.CATEGORYNAMES.PLANTS
 msgctxt "STRINGS.UI.CODEX.CATEGORYNAMES.PLANTS"
@@ -2350,7 +2350,7 @@ msgstr "<link=\"ROLES\">複製人間のスキル</link>"
 #. STRINGS.UI.CODEX.CATEGORYNAMES.ROOT
 msgctxt "STRINGS.UI.CODEX.CATEGORYNAMES.ROOT"
 msgid "<link=\"HOME\">Index</link>"
-msgstr "<link=\"HOME\">Index</link>"
+msgstr "<link=\"HOME\">目次</link>"
 
 #. STRINGS.UI.CODEX.CATEGORYNAMES.SICKNESS
 msgctxt "STRINGS.UI.CODEX.CATEGORYNAMES.SICKNESS"


### PR DESCRIPTION
データベースの目次に並ぶ項目名（タイトル名）を修正しました。
- `Tips` → `チュートリアル`
`Tips` のままで特に不都合はないのですが、子項目が全て`チュートリアル: `となっているので、そちらに合わせて統一感を出しました。
- `Notices` → `掲示`
内容を見る限り、広報や広告の類ばかりなので、`掲示`としました。おそらく社内の電光掲示板やプロジェクターなどで流されたコンテンツなのかもしれません。
- `Index` → `目次`
厳密に訳せば「索引」ですが、実態としては目次なので「目次」としています。