### PR TITLE
Autorepairの訳を修正（再）

### DIFF
--- a/po/buildings.po
+++ b/po/buildings.po
@@ -16,22 +16,22 @@ msgstr ""
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.NAME
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.NAME"
 msgid "Disable Disinfect"
-msgstr "お任せ消毒をやめる"
+msgstr "消毒の対象から外す"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.TOOLTIP"
 msgid "Do not automatically disinfect this building"
-msgstr "この設備が汚染されても、複製人間は指示がない限り一切消毒しなくなります"
+msgstr "指示がない限り、この設備を消毒させないようにします"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.ENABLE_AUTODISINFECT.NAME
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.ENABLE_AUTODISINFECT.NAME"
 msgid "Enable Disinfect"
-msgstr "お任せ消毒にする"
+msgstr "消毒の対象にする"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.ENABLE_AUTODISINFECT.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.ENABLE_AUTODISINFECT.TOOLTIP"
 msgid "Automatically disinfect this building when it becomes contaminated"
-msgstr "この設備が汚染されたとき、複製人間は自分の判断で消毒するようになります"
+msgstr "この設備が汚染されたとき、複製人間が自発的に消毒することを許します"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.NO_DISEASE.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.NO_DISEASE.TOOLTIP"
@@ -12801,22 +12801,23 @@ msgstr "<link=\"WOODGASGENERATOR\">薪ストーブ</link>"
 #. STRINGS.BUILDINGS.REPAIRABLE.DISABLE_AUTOREPAIR.NAME
 msgctxt "STRINGS.BUILDINGS.REPAIRABLE.DISABLE_AUTOREPAIR.NAME"
 msgid "Disable Autorepair"
-msgstr "お任せ修理をやめる"
+msgstr "修理の対象から外す"
 
+# 修理の命令(修理マーク)は実装されていない
 #. STRINGS.BUILDINGS.REPAIRABLE.DISABLE_AUTOREPAIR.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.REPAIRABLE.DISABLE_AUTOREPAIR.TOOLTIP"
 msgid "Only repair this building when ordered"
-msgstr "この設備が損傷しても、複製人間は指示がない限り一切修理しなくなります"
+msgstr "この設備が損傷しても、修理させないようにします"
 
 #. STRINGS.BUILDINGS.REPAIRABLE.ENABLE_AUTOREPAIR.NAME
 msgctxt "STRINGS.BUILDINGS.REPAIRABLE.ENABLE_AUTOREPAIR.NAME"
 msgid "Enable Autorepair"
-msgstr "お任せ修理にする"
+msgstr "修理の対象にする"
 
 #. STRINGS.BUILDINGS.REPAIRABLE.ENABLE_AUTOREPAIR.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.REPAIRABLE.ENABLE_AUTOREPAIR.TOOLTIP"
 msgid "Automatically repair this building when damaged"
-msgstr "この設備が損傷したとき、複製人間は自分の判断で修理するようになります"
+msgstr "この設備が損傷したとき、複製人間が自発的に修理することを許します"
 
 #~ msgctxt "STRINGS.BUILDINGS.PREFABS.SCANNERMODULE.EFFECT"
 #~ msgid "Automatically analyzes adjacent space while on a voyage."

--- a/po/buildings.po
+++ b/po/buildings.po
@@ -16,25 +16,22 @@ msgstr ""
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.NAME
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.NAME"
 msgid "Disable Disinfect"
-msgstr "指示して消毒させる"
+msgstr "お任せ消毒をやめる"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.TOOLTIP"
 msgid "Do not automatically disinfect this building"
-msgstr ""
-"この設備が汚染されても、指示がない限り複製人間に消毒させない設定に切り替えま"
-"す"
+msgstr "この設備が汚染されても、複製人間は指示がない限り一切消毒しなくなります"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.ENABLE_AUTODISINFECT.NAME
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.ENABLE_AUTODISINFECT.NAME"
 msgid "Enable Disinfect"
-msgstr "進んで消毒させる"
+msgstr "お任せ消毒にする"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.ENABLE_AUTODISINFECT.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.ENABLE_AUTODISINFECT.TOOLTIP"
 msgid "Automatically disinfect this building when it becomes contaminated"
-msgstr ""
-"この設備が汚染されたとき、複製人間に自分の判断で消毒させる設定に切り替えます"
+msgstr "この設備が汚染されたとき、複製人間は自分の判断で消毒するようになります"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.NO_DISEASE.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.AUTODISINFECTABLE.NO_DISEASE.TOOLTIP"
@@ -12804,24 +12801,22 @@ msgstr "<link=\"WOODGASGENERATOR\">薪ストーブ</link>"
 #. STRINGS.BUILDINGS.REPAIRABLE.DISABLE_AUTOREPAIR.NAME
 msgctxt "STRINGS.BUILDINGS.REPAIRABLE.DISABLE_AUTOREPAIR.NAME"
 msgid "Disable Autorepair"
-msgstr "指示して修理させる"
+msgstr "お任せ修理をやめる"
 
 #. STRINGS.BUILDINGS.REPAIRABLE.DISABLE_AUTOREPAIR.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.REPAIRABLE.DISABLE_AUTOREPAIR.TOOLTIP"
 msgid "Only repair this building when ordered"
-msgstr ""
-"この設備が損傷しても、指示がない限り複製人間に修理させない設定に切り替えます"
+msgstr "この設備が損傷しても、複製人間は指示がない限り一切修理しなくなります"
 
 #. STRINGS.BUILDINGS.REPAIRABLE.ENABLE_AUTOREPAIR.NAME
 msgctxt "STRINGS.BUILDINGS.REPAIRABLE.ENABLE_AUTOREPAIR.NAME"
 msgid "Enable Autorepair"
-msgstr "進んで修理させる"
+msgstr "お任せ修理にする"
 
 #. STRINGS.BUILDINGS.REPAIRABLE.ENABLE_AUTOREPAIR.TOOLTIP
 msgctxt "STRINGS.BUILDINGS.REPAIRABLE.ENABLE_AUTOREPAIR.TOOLTIP"
 msgid "Automatically repair this building when damaged"
-msgstr ""
-"この設備が損傷したとき、複製人間に自分の判断で修理させる設定に切り替えます"
+msgstr "この設備が損傷したとき、複製人間は自分の判断で修理するようになります"
 
 #~ msgctxt "STRINGS.BUILDINGS.PREFABS.SCANNERMODULE.EFFECT"
 #~ msgid "Automatically analyzes adjacent space while on a voyage."


### PR DESCRIPTION
設備の情報窓にあるボタン `Enable Autorepair` / `Disable Autorepair` の訳について、再度の修正案です。

自分で提案して訳を変更しておきながら、それを覆すことになるのは大変恐縮ですが、実際にしばらく遊んでみて、どうにも思ったほど分かりやすく感じられなかったため、改めて訳を練り直してみました。

【再度の修正案】
`お任せ修理にする` / `お任せ修理をやめる`

訳を練り直す際に参考にしたのが、同じく設備のボタンである`解体` / `解体をやめる`です。
このボタンはかなり分かりやすいと感じました。

こうした切り替え系のボタンに最低限求められることは、
1. 現在の状態が分かる
2. ボタンを押すことで、どんな状態に切り替わるのか分かる

の2つです。
「解体**をやめる**」という表現は、**動作**を意味し、**状態**の意味にはならないので、「ボタンを押すことで解体の指示が解除される（2.の達成）、つまり現在は解体することになっている（1.の達成）」と誤解の余地なく読み取れます。

それに倣い、`Autorepair` は「お任せ修理**にする**」 / 「お任せ修理**をやめる**」としてみました。

次に`お任せ修理`という表現にした理由についてです。
そもそも複製人間は、設定された優先度に従って作業を行うだけで、`Autorepair` を有効にしたからといって、必ずしもその設備を修理するとは限りません。現在の`修理させる`という表現は、（自分で提案しておいて何ですが）その意味で誤解を招くおそれがあります。
修理するか、**しないか**の判断まで含めて、複製人間に**すべて任せる**という意味で、`お任せ修理`としています。

実際にこの文言でテストプレイしてみましたが、実際の仕様に照らしても、かなり違和感なくボタンの文言を読むことができました。（自画自賛）
ご検討をお願いします。