### PR TITLE
Radbolt Storageを燃料と翻訳していたのをRADボルトに変更

### DIFF
--- a/strings.po
+++ b/strings.po
@@ -8502,7 +8502,7 @@ msgctxt "STRINGS.BUILDINGS.PREFABS.HEPENGINE.LOGIC_PORT_STORAGE_ACTIVE"
 msgid ""
 "Sends a <b><style=\"logic_on\">Green Signal</style></b> when its Radbolt "
 "Storage is full"
-msgstr "燃料が満載なら<b><style=\"logic_on\">グリーン</style></b>を送信"
+msgstr "RADボルトが満載なら<b><style=\"logic_on\">グリーン</style></b>を送信"
 
 #. STRINGS.BUILDINGS.PREFABS.HEPENGINE.LOGIC_PORT_STORAGE_INACTIVE
 msgctxt "STRINGS.BUILDINGS.PREFABS.HEPENGINE.LOGIC_PORT_STORAGE_INACTIVE"


### PR DESCRIPTION
ロケットエンジン以外にも使われるメッセージをロケットエンジン限定だと勘違いしたのだと思います。
材料工学端末でも使われているので「燃料」は不適格。