### PR TITLE
Edibleの翻訳の調整

### DIFF
--- a/strings.po
+++ b/strings.po
@@ -57034,7 +57034,7 @@ msgstr "治療関連の配送"
 #. STRINGS.MISC.TAGS.EDIBLE
 msgctxt "STRINGS.MISC.TAGS.EDIBLE"
 msgid "Edible"
-msgstr "食料品"
+msgstr "食品"
 
 #. STRINGS.MISC.TAGS.EGG
 msgctxt "STRINGS.MISC.TAGS.EGG"

--- a/strings.po
+++ b/strings.po
@@ -29499,7 +29499,7 @@ msgstr ""
 msgctxt "STRINGS.CREATURES.SPECIES.COLDWHEAT.DOMESTICATEDDESC"
 msgid ""
 "This plant produces edible <link=\"COLDWHEATSEED\">Sleet Wheat Grain</link>."
-msgstr "この植物は<link=\"COLDWHEATSEED\">雪ん小麦の種籾</link>を生産します。"
+msgstr "この植物は食用の<link=\"COLDWHEATSEED\">雪ん小麦の種籾</link>を生産します。"
 
 #. STRINGS.CREATURES.SPECIES.COLDWHEAT.NAME
 msgctxt "STRINGS.CREATURES.SPECIES.COLDWHEAT.NAME"
@@ -31377,8 +31377,8 @@ msgid ""
 "Waterweeds thrive in salty water and can be harvested for fresh, edible "
 "<link=\"LETTUCE\">Lettuce</link>."
 msgstr ""
-"水草は塩が溶けた水の中でよく育ち、食用可能で新鮮な<link=\"LETTUCE\">レタス</"
-"link>を生産します。"
+"水草は塩が溶けた水の中でよく育ち、新鮮な食用<link=\"LETTUCE\">レタス</link>"
+"を生産します。"
 
 #. STRINGS.CREATURES.SPECIES.SEALETTUCE.DOMESTICATEDDESC
 msgctxt "STRINGS.CREATURES.SPECIES.SEALETTUCE.DOMESTICATEDDESC"
@@ -32041,7 +32041,7 @@ msgstr ""
 msgctxt "STRINGS.CREATURES.SPECIES.SWAMPHARVESTPLANT.DOMESTICATEDDESC"
 msgid "This plant produces edible <link=\"SWAMPFRUIT\">Bog Jellies</link>."
 msgstr ""
-"この植物は食用可能な<link=\"SWAMPFRUIT\">泥炭地ゼリー</link>を生産します。"
+"この植物は食用の<link=\"SWAMPFRUIT\">泥炭地ゼリー</link>を生産します。"
 
 #. STRINGS.CREATURES.SPECIES.SWAMPHARVESTPLANT.NAME
 msgctxt "STRINGS.CREATURES.SPECIES.SWAMPHARVESTPLANT.NAME"
@@ -53110,7 +53110,7 @@ msgstr ""
 #. STRINGS.ITEMS.FOOD.MUSHROOM.DESC
 msgctxt "STRINGS.ITEMS.FOOD.MUSHROOM.DESC"
 msgid "An edible, flavorless fungus that grew in the dark."
-msgstr "暗闇の中で育つ、風味のない食用のキノコです。"
+msgstr "暗闇の中で育つ、風味のない食用キノコです。"
 
 #. STRINGS.ITEMS.FOOD.MUSHROOM.NAME
 msgctxt "STRINGS.ITEMS.FOOD.MUSHROOM.NAME"
@@ -57034,7 +57034,7 @@ msgstr "治療関連の配送"
 #. STRINGS.MISC.TAGS.EDIBLE
 msgctxt "STRINGS.MISC.TAGS.EDIBLE"
 msgid "Edible"
-msgstr "食用"
+msgstr "食料品"
 
 #. STRINGS.MISC.TAGS.EGG
 msgctxt "STRINGS.MISC.TAGS.EGG"


### PR DESCRIPTION
Edible+動植物の場合は「食用(の)」に統一（食用可能は冗長なので調整）
Edibleの名詞形は「食料品」に変更