### PR TITLE
タイトルのアップデート名の表示を空欄に変更

### DIFF
--- a/strings.po
+++ b/strings.po
@@ -75467,10 +75467,12 @@ msgctxt "STRINGS.UI.FRONTEND.MODS.WORKSHOP"
 msgid "STEAM WORKSHOP"
 msgstr "STEAM WORKSHOP"
 
+# この項目についてはmsgstrは翻訳は入れない
+# アップデートがあってもmsgctxtが再設定されないので最新のアップデート名が上書きされてしまう
 #. STRINGS.UI.FRONTEND.MOTD.IMAGE_HEADER
 msgctxt "STRINGS.UI.FRONTEND.MOTD.IMAGE_HEADER"
 msgid "FAST FRIENDS"
-msgstr "FAST FRIENDS"
+msgstr ""
 
 #. STRINGS.UI.FRONTEND.MOTD.NEWS_BODY
 msgctxt "STRINGS.UI.FRONTEND.MOTD.NEWS_BODY"


### PR DESCRIPTION
タイトルのアップデート名が翻訳ファイルがリリースされるまで前のものが表示され続けるという現象がたびたび発生していました。
翻訳ファイルのテクニカルな運用になりますが、STRINGS.UI.FRONTEND.MOTD.IMAGE_HEADERについてmsgstrを空欄にすることでアップデートが来た際にすぐアップデート名が反映されるようになります。

GNUのgettextの仕様上はmsgidが変わっていれば一致しないものとして処理されるはずなのですが、どうもそうでないような動きをしているので空欄で良いのではないかと思います。
ONIの独自実装なのかUnityのライブラリにそういうルールがあるのかは不明です。