### PR TITLE
Useless Machineの日本語の定訳は役に立たない機械

### DIFF
--- a/strings.po
+++ b/strings.po
@@ -82974,7 +82974,7 @@ msgstr "これで何するの？"
 #. STRINGS.UI.SPACEARTIFACTS.ORACLE.NAME
 msgctxt "STRINGS.UI.SPACEARTIFACTS.ORACLE.NAME"
 msgid "Useless Machine"
-msgstr "役立たずの機械"
+msgstr "役に立たない機械"
 
 #. STRINGS.UI.SPACEARTIFACTS.PACUPERCOLATOR.ARTIFACT
 #, fuzzy


### PR DESCRIPTION
細かいところですが、Useless Machineは日本語では「役に立たない機械」と訳されます。
Wikipediaにもページがあります。形状も同じなのでこれで間違いないでしょう。
https://ja.wikipedia.org/wiki/役に立たない機械