### PR TITLE
INPUT_BINDINGS 翻訳

### DIFF
--- a/po/input_bindings.po
+++ b/po/input_bindings.po
@@ -743,7 +743,7 @@ msgstr "視点を上に"
 #| msgid "Building Menu"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN1"
 msgid "Base Build Menu"
-msgstr "設備メニュー"
+msgstr "基地設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN10
 #, fuzzy
@@ -751,7 +751,7 @@ msgstr "設備メニュー"
 #| msgid "Building Menu"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN10"
 msgid "Station Build Menu"
-msgstr "設備メニュー"
+msgstr "端末設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN11
 #, fuzzy
@@ -759,7 +759,7 @@ msgstr "設備メニュー"
 #| msgid "Building Menu"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN11"
 msgid "Utility Build Menu"
-msgstr "設備メニュー"
+msgstr "その他設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN12
 #, fuzzy
@@ -767,7 +767,7 @@ msgstr "設備メニュー"
 #| msgid "Automation Wires"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN12"
 msgid "Automation Build Menu"
-msgstr "自動化ワイヤー"
+msgstr "自動化設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN13
 #, fuzzy
@@ -775,7 +775,7 @@ msgstr "自動化ワイヤー"
 #| msgid "Shipping Build"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN13"
 msgid "Shipping Build Menu"
-msgstr "輸送設備"
+msgstr "輸送設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN14
 #, fuzzy
@@ -783,7 +783,7 @@ msgstr "輸送設備"
 #| msgid "Rocket burden: "
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN14"
 msgid "Rocketry Build Menu"
-msgstr "ロケットの総重量: "
+msgstr "ロケット設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN15
 #, fuzzy
@@ -791,7 +791,7 @@ msgstr "ロケットの総重量: "
 #| msgid "Radiation Mood Ring"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN15"
 msgid "Radiation Build Menu"
-msgstr "放射線ムードリング"
+msgstr "放射線設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN2
 #, fuzzy
@@ -799,7 +799,7 @@ msgstr "放射線ムードリング"
 #| msgid "Building Menu"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN2"
 msgid "Oxygen Build Menu"
-msgstr "設備メニュー"
+msgstr "酸素設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN3
 #, fuzzy
@@ -807,7 +807,7 @@ msgstr "設備メニュー"
 #| msgid "Building Menu"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN3"
 msgid "Power Build Menu"
-msgstr "設備メニュー"
+msgstr "電力設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN4
 #, fuzzy
@@ -815,7 +815,7 @@ msgstr "設備メニュー"
 #| msgid "Building Menu"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN4"
 msgid "Food Build Menu"
-msgstr "設備メニュー"
+msgstr "食糧設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN5
 #, fuzzy
@@ -823,7 +823,7 @@ msgstr "設備メニュー"
 #| msgid "Building Menu"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN5"
 msgid "Plumbing Build Menu"
-msgstr "設備メニュー"
+msgstr "配管設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN6
 #, fuzzy
@@ -831,7 +831,7 @@ msgstr "設備メニュー"
 #| msgid "Ventilation"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN6"
 msgid "Ventilation Build Menu"
-msgstr "換気"
+msgstr "換気設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN7
 #, fuzzy
@@ -839,7 +839,7 @@ msgstr "換気"
 #| msgid "Refinement"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN7"
 msgid "Refinement Build Menu"
-msgstr "精製"
+msgstr "精製設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN8
 #, fuzzy
@@ -847,7 +847,7 @@ msgstr "精製"
 #| msgid "Building Menu"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN8"
 msgid "Medicine Build Menu"
-msgstr "設備メニュー"
+msgstr "医療設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PLAN9
 #, fuzzy
@@ -855,7 +855,7 @@ msgstr "設備メニュー"
 #| msgid "Configure Building"
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PLAN9"
 msgid "Furniture Build Menu"
-msgstr "設備設定"
+msgstr "家具設備メニュー"
 
 #. STRINGS.INPUT_BINDINGS.ROOT.PRIORITIZE
 msgctxt "STRINGS.INPUT_BINDINGS.ROOT.PRIORITIZE"


### PR DESCRIPTION
元の `Plan X` の翻訳から `XXX Build Menu` と記述が長くなっていたので翻訳をフルで入れてみました。
これらの翻訳ストリングがゲームのどこで使われているのか見つけられなかったので表示上問題がないかは分かりません。