### PR TITLE
宇宙関連施設の訳を修正（再）

### DIFF
--- a/po/building.po
+++ b/po/building.po
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.3.1\n"
+"X-Generator: Poedit 3.3.2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. STRINGS.BUILDING.DETAILS.USE_COUNT
@@ -1180,7 +1180,7 @@ msgstr "埋没"
 #. STRINGS.BUILDING.STATUSITEMS.ENTOMBED.NOTIFICATION_NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.ENTOMBED.NOTIFICATION_NAME"
 msgid "Building entombment"
-msgstr "設備は埋もれています"
+msgstr "設備が埋もれている"
 
 #. STRINGS.BUILDING.STATUSITEMS.ENTOMBED.NOTIFICATION_TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.ENTOMBED.NOTIFICATION_TOOLTIP"
@@ -3424,7 +3424,7 @@ msgstr "複製人間はこのロケットモジュールまで辿り着けませ
 #. STRINGS.BUILDING.STATUSITEMS.PATH_NOT_CLEAR.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.PATH_NOT_CLEAR.NAME"
 msgid "Launch Path Blocked"
-msgstr "ロケット打ち上げ軌道阻害"
+msgstr "打ち上げ軌道に障害物がある"
 
 #. STRINGS.BUILDING.STATUSITEMS.PATH_NOT_CLEAR.TILE_FORMAT
 msgctxt "STRINGS.BUILDING.STATUSITEMS.PATH_NOT_CLEAR.TILE_FORMAT"
@@ -3439,10 +3439,10 @@ msgid ""
 "\n"
 "This rocket requires a clear flight path for launch"
 msgstr ""
-"このロケットの打ち上げ軌道に阻害物があります:\n"
+"このロケットの打ち上げ軌道に障害物があります:\n"
 "    • {0}\n"
 "\n"
-"ロケットの航行路は視界良好でなければなりません"
+"ロケットを打ち上げるには、航行経路を確保してください"
 
 #. STRINGS.BUILDING.STATUSITEMS.PENDINGDECONSTRUCTION.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.PENDINGDECONSTRUCTION.NAME"
@@ -3680,7 +3680,7 @@ msgstr "現在産出量: {ENERGY_RATE}"
 #. STRINGS.BUILDING.STATUSITEMS.RAILGUN_NO_DESTINATION.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.RAILGUN_NO_DESTINATION.NAME"
 msgid "No Delivery Destination"
-msgstr "配達先なし"
+msgstr "配達先がない"
 
 #. STRINGS.BUILDING.STATUSITEMS.RAILGUN_NO_DESTINATION.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.RAILGUN_NO_DESTINATION.TOOLTIP"
@@ -3690,7 +3690,7 @@ msgstr "配達先が指定されていません"
 #. STRINGS.BUILDING.STATUSITEMS.RAILGUN_PATH_NOT_CLEAR.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.RAILGUN_PATH_NOT_CLEAR.NAME"
 msgid "Launch Path Blocked"
-msgstr "打ち上げ軌道阻害"
+msgstr "射出軌道に障害物がある"
 
 #. STRINGS.BUILDING.STATUSITEMS.RAILGUN_PATH_NOT_CLEAR.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.RAILGUN_PATH_NOT_CLEAR.TOOLTIP"
@@ -3700,9 +3700,9 @@ msgid ""
 "\n"
 "This launcher requires a clear path to launch payloads"
 msgstr ""
-"<link=\"RAILGUN\">星間ランチャー</link>の軌道を阻害するものがあります\n"
+"この<link=\"RAILGUN\">星間ランチャー</link>の射出軌道に障害物があります\n"
 "\n"
-"ランチャーの軌道を確保してください"
+"ランチャーで貨物を射ち出すには、経路を確保してください"
 
 #. STRINGS.BUILDING.STATUSITEMS.RAILGUNCOOLDOWN.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.RAILGUNCOOLDOWN.NAME"
@@ -3713,7 +3713,7 @@ msgstr "レールの保守点検中: {timeleft}"
 msgctxt "STRINGS.BUILDING.STATUSITEMS.RAILGUNCOOLDOWN.TOOLTIP"
 msgid ""
 "This building automatically performs routine maintenance every {x} launches"
-msgstr "この設備は、{x}回の発射ごとに定例の保守点検作業を自動的に行います"
+msgstr "この設備は、{x}回の射出ごとに定例の保守点検作業を自動的に行います"
 
 #. STRINGS.BUILDING.STATUSITEMS.RAILGUNPAYLOADNEEDSEMPTYING.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.RAILGUNPAYLOADNEEDSEMPTYING.NAME"
@@ -3935,13 +3935,13 @@ msgid ""
 "Tall rockets may not be able to land on this <style=\"KKeyword\">Rocket "
 "Platform</style>"
 msgstr ""
-"長いロケットはこの<style=\"KKeyword\">ロケット発射台</style>に着陸できないか"
-"もしれません"
+"全長の長いロケットは、この<style=\"KKeyword\">ロケット発射台</style>に着陸で"
+"きないかもしれません"
 
 #. STRINGS.BUILDING.STATUSITEMS.ROCKETRESTRICTIONACTIVE.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.ROCKETRESTRICTIONACTIVE.NAME"
 msgid "Access: Restricted"
-msgstr "アクセス: 制限あり"
+msgstr "使用規制: あり"
 
 #. STRINGS.BUILDING.STATUSITEMS.ROCKETRESTRICTIONACTIVE.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.ROCKETRESTRICTIONACTIVE.TOOLTIP"
@@ -3950,14 +3950,15 @@ msgid ""
 "\n"
 "Controlled by a <link=\"ROCKETCONTROLSTATION\">Rocket Control Station</link>"
 msgstr ""
-"この設備は制限されており、積み込みは行えますが操作できません\n"
+"この設備は規制中のため使用できません (内容物の収納は可能です)\n"
 "\n"
-"<link=\"ROCKETCONTROLSTATION\">ロケット制御端末</link>によって制御されます"
+"この規制は<link=\"ROCKETCONTROLSTATION\">ロケット制御端末</link>によって制御"
+"されています"
 
 #. STRINGS.BUILDING.STATUSITEMS.ROCKETRESTRICTIONINACTIVE.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.ROCKETRESTRICTIONINACTIVE.NAME"
 msgid "Access: Not Restricted"
-msgstr "アクセス: 制限なし"
+msgstr "使用規制: なし"
 
 #. STRINGS.BUILDING.STATUSITEMS.ROCKETRESTRICTIONINACTIVE.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.ROCKETRESTRICTIONINACTIVE.TOOLTIP"
@@ -3966,9 +3967,10 @@ msgid ""
 "\n"
 "Controlled by a <link=\"ROCKETCONTROLSTATION\">Rocket Control Station</link>"
 msgstr ""
-"この設備の操作は制限されていません\n"
+"この設備は規制されていないため使用できます\n"
 "\n"
-"<link=\"ROCKETCONTROLSTATION\">ロケット制御端末</link>によって制御されます"
+"この規制は<link=\"ROCKETCONTROLSTATION\">ロケット制御端末</link>によって制御"
+"されています"
 
 #. STRINGS.BUILDING.STATUSITEMS.ROCKETSTRANDED.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.ROCKETSTRANDED.NAME"

--- a/po/buildings.po
+++ b/po/buildings.po
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.3.1\n"
+"X-Generator: Poedit 3.3.2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. STRINGS.BUILDINGS.AUTODISINFECTABLE.DISABLE_AUTODISINFECT.NAME
@@ -5987,8 +5987,8 @@ msgstr ""
 "<link=\"PETROLEUM\">石油</link>を燃やし、中距離宇宙探索ロケットの推進力としま"
 "す。\n"
 "\n"
-"小型石油エンジンは<link=\"KEROSENEENGINE\">石油エンジン</link>と同等の速度を"
-"持ちますが、ロケット全長制限はそれよりも小さくなります。\n"
+"小型石油エンジンは<link=\"KEROSENEENGINE\">石油エンジン</link>と速度は同じで"
+"すが、ロケットの全長制限では劣ります。\n"
 "\n"
 "エンジンは<link=\"LAUNCHPAD\">ロケット発射台</link>経由で建築する必要がありま"
 "す。\n"
@@ -11695,7 +11695,7 @@ msgstr "<link=\"RADIATIONLIGHT\">放射線ランプ</link>"
 #. STRINGS.BUILDINGS.PREFABS.RAILGUN.DESC
 msgctxt "STRINGS.BUILDINGS.PREFABS.RAILGUN.DESC"
 msgid "It's tempting to climb inside but trust me... don't."
-msgstr "中に登ってみたい誘惑に駆られるけど、登るなよ、絶対登るなよ。"
+msgstr "中に乗り込んでみたい誘惑に駆られるけど、乗るなよ、絶対乗るなよ。"
 
 #. STRINGS.BUILDINGS.PREFABS.RAILGUN.EFFECT
 msgctxt "STRINGS.BUILDINGS.PREFABS.RAILGUN.EFFECT"
@@ -11709,29 +11709,29 @@ msgid ""
 "\n"
 "Cannot transport Duplicants."
 msgstr ""
-"<link=\"RAILGUNPAYLOAD\">星間貨物</link>を発射します。\n"
+"<link=\"RAILGUNPAYLOAD\">星間貨物</link>を射出します。\n"
 "\n"
-"<link=\"ELEMENTSSOLID\">固体</link>、<link=\"ELEMENTSLIQUID\">液体</link>、"
-"<link=\"ELEMENTSGAS\">気体</link>を積載することができます。\n"
+"貨物には、<link=\"ELEMENTSSOLID\">固体</link>、<link=\"ELEMENTSLIQUID\">液体"
+"</link>、<link=\"ELEMENTSGAS\">気体</link>を積載することができます。\n"
 "\n"
-"複製人間が運送することはできません。"
+"複製人間を運ぶことはできません。"
 
 #. STRINGS.BUILDINGS.PREFABS.RAILGUN.LOGIC_PORT
 msgctxt "STRINGS.BUILDINGS.PREFABS.RAILGUN.LOGIC_PORT"
 msgid "Launch Toggle"
-msgstr "発射切替"
+msgstr "射出する / しない"
 
 #. STRINGS.BUILDINGS.PREFABS.RAILGUN.LOGIC_PORT_ACTIVE
 msgctxt "STRINGS.BUILDINGS.PREFABS.RAILGUN.LOGIC_PORT_ACTIVE"
 msgid ""
 "<b><style=\"logic_on\">Green Signal</style></b>: Enable payload launching."
-msgstr "<b><style=\"logic_on\">グリーン</style></b>: 貨物の発射を有効にする。"
+msgstr "<b><style=\"logic_on\">グリーン</style></b>: 貨物を射出します"
 
 #. STRINGS.BUILDINGS.PREFABS.RAILGUN.LOGIC_PORT_INACTIVE
 msgctxt "STRINGS.BUILDINGS.PREFABS.RAILGUN.LOGIC_PORT_INACTIVE"
 msgid ""
 "<b><style=\"logic_off\">Red Signal</style></b>: Disable payload launching."
-msgstr "<b><style=\"logic_off\">レッド</style></b>: 貨物の発射を無効にする。"
+msgstr "<b><style=\"logic_off\">レッド</style></b>: 貨物を射出しません"
 
 #. STRINGS.BUILDINGS.PREFABS.RAILGUN.NAME
 msgctxt "STRINGS.BUILDINGS.PREFABS.RAILGUN.NAME"
@@ -12024,7 +12024,8 @@ msgid ""
 "Assigned Duplicants must have the <link=\"ROCKETPILOTING1\">Rocket Piloting</"
 "link> skill."
 msgstr ""
-"複製人間にロケットを操縦させたり内装設備へのアクセスを制御します。\n"
+"複製人間にロケットを操縦させたり、ロケット内設備の使用を規制したりできま"
+"す。\n"
 "\n"
 "<link=\"ROCKETPILOTING1\">ロケット操縦</link>スキルを持った複製人間を割り当て"
 "てください。"
@@ -12032,7 +12033,7 @@ msgstr ""
 #. STRINGS.BUILDINGS.PREFABS.ROCKETCONTROLSTATION.LOGIC_PORT
 msgctxt "STRINGS.BUILDINGS.PREFABS.ROCKETCONTROLSTATION.LOGIC_PORT"
 msgid "Restrict Building Usage"
-msgstr "設備の使用を制限"
+msgstr "設備の使用規制"
 
 #. STRINGS.BUILDINGS.PREFABS.ROCKETCONTROLSTATION.LOGIC_PORT_ACTIVE
 msgctxt "STRINGS.BUILDINGS.PREFABS.ROCKETCONTROLSTATION.LOGIC_PORT_ACTIVE"
@@ -12040,7 +12041,7 @@ msgid ""
 "<b><style=\"logic_on\">Green Signal</style></b>: Restrict access to interior "
 "buildings"
 msgstr ""
-"<b><style=\"logic_on\">グリーン</style></b>: 内装設備へのアクセスを制限します"
+"<b><style=\"logic_on\">グリーン</style></b>: ロケット内設備の使用を規制します"
 
 #. STRINGS.BUILDINGS.PREFABS.ROCKETCONTROLSTATION.LOGIC_PORT_INACTIVE
 msgctxt "STRINGS.BUILDINGS.PREFABS.ROCKETCONTROLSTATION.LOGIC_PORT_INACTIVE"
@@ -12048,7 +12049,7 @@ msgid ""
 "<b><style=\"logic_off\">Red Signal</style></b>: Unrestrict access to "
 "interior buildings"
 msgstr ""
-"<b><style=\"logic_off\">レッド</style></b>: 内装設備へのアクセスを制限しませ"
+"<b><style=\"logic_off\">レッド</style></b>: ロケット内設備の使用を規制しませ"
 "ん"
 
 #. STRINGS.BUILDINGS.PREFABS.ROCKETCONTROLSTATION.NAME

--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.3.1\n"
+"X-Generator: Poedit 3.3.2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. STRINGS.DUPLICANTS.ARRIVALTIME
@@ -12162,7 +12162,7 @@ msgstr "この複製人間はもっとも単純な設備でさえ組み立てる
 #. STRINGS.DUPLICANTS.TRAITS.CANTBUILD.NAME
 msgctxt "STRINGS.DUPLICANTS.TRAITS.CANTBUILD.NAME"
 msgid "Unconstructive"
-msgstr "非建築的"
+msgstr "非建設的"
 
 #. STRINGS.DUPLICANTS.TRAITS.CANTCOOK.DESC
 msgctxt "STRINGS.DUPLICANTS.TRAITS.CANTCOOK.DESC"

--- a/po/ui.po
+++ b/po/ui.po
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Poedit 3.3.1\n"
+"X-Generator: Poedit 3.3.2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. STRINGS.UI.ACTIONS
@@ -786,7 +786,7 @@ msgstr "    • 設備: {buildinglist}"
 #. STRINGS.UI.BUILDINGEFFECTS.ROCKETRESTRICTION_HEADER
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.ROCKETRESTRICTION_HEADER"
 msgid "Restriction Control:"
-msgstr "操作制限:"
+msgstr "使用規制の制御:"
 
 #. STRINGS.UI.BUILDINGEFFECTS.SCALE_GROWTH
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.SCALE_GROWTH"
@@ -1702,14 +1702,14 @@ msgid ""
 "\n"
 "{buildinglist}"
 msgstr ""
-"この端末は、以下の設備の稼働状況を管理します:\n"
+"この端末が使用を規制できる設備は次のとおり:\n"
 "\n"
 "{buildinglist}"
 
 #. STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.ROCKETRESTRICTION_HEADER
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.ROCKETRESTRICTION_HEADER"
 msgid "Controls whether a building is operational within a rocket interior"
-msgstr "設備がロケット内で稼働可能かを制御します"
+msgstr "ロケット内設備の使用を規制するかどうか制御します"
 
 #. STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.SCALE_GROWTH
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.SCALE_GROWTH"
@@ -2138,7 +2138,7 @@ msgstr "最大ロケット全長: "
 #. STRINGS.UI.CLUSTERMAP.ROCKETS.MAX_HEIGHT.NAME_RAW
 msgctxt "STRINGS.UI.CLUSTERMAP.ROCKETS.MAX_HEIGHT.NAME_RAW"
 msgid "Height: "
-msgstr "ロケット全長: "
+msgstr "モジュールの全長: "
 
 #. STRINGS.UI.CLUSTERMAP.ROCKETS.MAX_HEIGHT.TOOLTIP
 msgctxt "STRINGS.UI.CLUSTERMAP.ROCKETS.MAX_HEIGHT.TOOLTIP"
@@ -2158,12 +2158,12 @@ msgstr "{0}は(自身を含まず)最大 {1} 個のモジュールを接続で�
 #. STRINGS.UI.CLUSTERMAP.ROCKETS.MODULE_STATS.NAME
 msgctxt "STRINGS.UI.CLUSTERMAP.ROCKETS.MODULE_STATS.NAME"
 msgid "Module Stats: "
-msgstr "モジュールの状態: "
+msgstr "モジュールの性能: "
 
 #. STRINGS.UI.CLUSTERMAP.ROCKETS.MODULE_STATS.NAME_HEADER
 msgctxt "STRINGS.UI.CLUSTERMAP.ROCKETS.MODULE_STATS.NAME_HEADER"
 msgid "Module Stats"
-msgstr "モジュールの状態"
+msgstr "モジュールの性能"
 
 #. STRINGS.UI.CLUSTERMAP.ROCKETS.MODULE_STATS.TOOLTIP
 msgctxt "STRINGS.UI.CLUSTERMAP.ROCKETS.MODULE_STATS.TOOLTIP"
@@ -2234,7 +2234,7 @@ msgstr ""
 "<b>ロケット速度</b>とは、<b>エンジン出力</b>を<b>総重量</b>で割ったもので"
 "す。\n"
 "\n"
-"オートパイロット中のロケットは減速します。\n"
+"自動操縦中はロケットの速度が低下します。\n"
 "\n"
 "ロケット速度は複製人間のスキルによって上昇させることができます。"
 
@@ -20988,17 +20988,17 @@ msgstr "発射台なし"
 #. STRINGS.UI.STARMAP.LAUNCHCHECKLIST.ON_LAUNCHPAD.TOOLTIP.FAILURE
 msgctxt "STRINGS.UI.STARMAP.LAUNCHCHECKLIST.ON_LAUNCHPAD.TOOLTIP.FAILURE"
 msgid "Not on a launch pad"
-msgstr "発射台上にない"
+msgstr "発射台上にありません"
 
 #. STRINGS.UI.STARMAP.LAUNCHCHECKLIST.ON_LAUNCHPAD.TOOLTIP.READY
 msgctxt "STRINGS.UI.STARMAP.LAUNCHCHECKLIST.ON_LAUNCHPAD.TOOLTIP.READY"
 msgid "On a launch pad"
-msgstr "発射台上"
+msgstr "発射台上にあります"
 
 #. STRINGS.UI.STARMAP.LAUNCHCHECKLIST.ON_LAUNCHPAD.TOOLTIP.WARNING
 msgctxt "STRINGS.UI.STARMAP.LAUNCHCHECKLIST.ON_LAUNCHPAD.TOOLTIP.WARNING"
 msgid "No launch pad"
-msgstr "発射台なし"
+msgstr "発射台がありません"
 
 #. STRINGS.UI.STARMAP.LAUNCHCHECKLIST.PILOT_BOARDED.FAILURE
 msgctxt "STRINGS.UI.STARMAP.LAUNCHCHECKLIST.PILOT_BOARDED.FAILURE"
@@ -23659,7 +23659,7 @@ msgctxt ""
 "STRINGS.UI.UISIDESCREENS.CLUSTERDESTINATIONSIDESCREEN."
 "DROPDOWN_TOOLTIP_FIRST_AVAILABLE"
 msgid "Select the first available landing site"
-msgstr "有効な着陸地点を指定します"
+msgstr "はじめに空いた発射台に着陸します"
 
 #. STRINGS.UI.UISIDESCREENS.CLUSTERDESTINATIONSIDESCREEN.DROPDOWN_TOOLTIP_PAD_DISABLED
 msgctxt ""
@@ -23673,14 +23673,14 @@ msgctxt ""
 "STRINGS.UI.UISIDESCREENS.CLUSTERDESTINATIONSIDESCREEN."
 "DROPDOWN_TOOLTIP_PATH_OBSTRUCTED"
 msgid "Landing path obstructed"
-msgstr "着陸進路が阻害されています"
+msgstr "着陸進路に障害物があります"
 
 #. STRINGS.UI.UISIDESCREENS.CLUSTERDESTINATIONSIDESCREEN.DROPDOWN_TOOLTIP_SITE_OBSTRUCTED
 msgctxt ""
 "STRINGS.UI.UISIDESCREENS.CLUSTERDESTINATIONSIDESCREEN."
 "DROPDOWN_TOOLTIP_SITE_OBSTRUCTED"
 msgid "Landing position on the platform is obstructed"
-msgstr "着陸地点であるロケット発射台が阻害されています"
+msgstr "着陸地点であるロケット発射台に障害物があります"
 
 #. STRINGS.UI.UISIDESCREENS.CLUSTERDESTINATIONSIDESCREEN.DROPDOWN_TOOLTIP_TOO_SHORT
 msgctxt ""
@@ -23694,7 +23694,7 @@ msgctxt ""
 "STRINGS.UI.UISIDESCREENS.CLUSTERDESTINATIONSIDESCREEN."
 "DROPDOWN_TOOLTIP_VALID_SITE"
 msgid "Land at {0} when the site is clear"
-msgstr "準備ができ次第{0}に着陸します"
+msgstr "場所が空き次第、{0}に着陸します"
 
 #. STRINGS.UI.UISIDESCREENS.CLUSTERDESTINATIONSIDESCREEN.FIRSTAVAILABLE
 msgctxt "STRINGS.UI.UISIDESCREENS.CLUSTERDESTINATIONSIDESCREEN.FIRSTAVAILABLE"
@@ -23713,7 +23713,7 @@ msgstr "元の発射地点と目的地の間を往復させるかどうか切り
 msgctxt ""
 "STRINGS.UI.UISIDESCREENS.CLUSTERDESTINATIONSIDESCREEN.NO_TALL_SITES_AVAILABLE"
 msgid "No landing sites fit the height of this rocket"
-msgstr "このロケットの全長に合った着陸地点がありません"
+msgstr "このロケットの全長を収容できる着陸地点がありません"
 
 #. STRINGS.UI.UISIDESCREENS.CLUSTERDESTINATIONSIDESCREEN.NONEAVAILABLE
 msgctxt "STRINGS.UI.UISIDESCREENS.CLUSTERDESTINATIONSIDESCREEN.NONEAVAILABLE"
@@ -25964,7 +25964,7 @@ msgstr "ランチャーの目的地には{0}が指定されています"
 #. STRINGS.UI.UISIDESCREENS.RAILGUNSIDESCREEN.MINIMUM_PAYLOAD_MASS
 msgctxt "STRINGS.UI.UISIDESCREENS.RAILGUNSIDESCREEN.MINIMUM_PAYLOAD_MASS"
 msgid "Minimum launch mass:"
-msgstr "最小発射質量:"
+msgstr "最小射出質量:"
 
 #. STRINGS.UI.UISIDESCREENS.RAILGUNSIDESCREEN.NO_SELECTED_LAUNCH_TARGET
 msgctxt "STRINGS.UI.UISIDESCREENS.RAILGUNSIDESCREEN.NO_SELECTED_LAUNCH_TARGET"
@@ -26072,7 +26072,7 @@ msgstr "研究を選択する"
 #. STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.ADDMODULE.DESC
 msgctxt "STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.ADDMODULE.DESC"
 msgid "Add a new module above this one"
-msgstr "このモジュールの上部に新しいモジュールを追加します"
+msgstr "このモジュールの直上に新たなモジュールを追加します"
 
 #. STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.ADDMODULE.INVALID
 msgctxt "STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.ADDMODULE.INVALID"
@@ -26080,8 +26080,8 @@ msgid ""
 "Modules cannot be added above this module, or there is no room above to add "
 "a module"
 msgstr ""
-"このモジュール上に新しくモジュールを追加することができないか、モジュールを追"
-"加するスペースがありません"
+"上部にモジュールを追加するための場所が足りないか、このモジュールは自身より上"
+"にモジュールを持つことができません"
 
 #. STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.BUTTONCHANGEMODULE.DESC
 msgctxt ""
@@ -26093,7 +26093,7 @@ msgstr "このモジュールを別のモジュールへ変更します"
 msgctxt ""
 "STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.BUTTONCHANGEMODULE.INVALID"
 msgid "This module cannot be changed to a different type"
-msgstr "このモジュールは別のタイプに変更できません"
+msgstr "このモジュールは別の種類に変更できません"
 
 #. STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.BUTTONREMOVEMODULE.DESC
 msgctxt ""
@@ -26111,7 +26111,7 @@ msgstr "このモジュールは解体できません"
 msgctxt ""
 "STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.BUTTONSWAPMODULEDOWN.DESC"
 msgid "Swap this rocket module with the one below"
-msgstr "下のモジュールと入れ替えます"
+msgstr "このモジュールを直下にあるモジュールと入れ替えます"
 
 #. STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.BUTTONSWAPMODULEDOWN.INVALID
 msgctxt ""
@@ -26123,19 +26123,17 @@ msgid ""
 "    • A module below may be unable to fit into the space above it.\n"
 "    • This module may be unable to fit into the space below it."
 msgstr ""
-"入れ替え可能なモジュールがありません。\n"
+"直下のモジュールと入れ替えることはできません。理由は次のいずれかです。\n"
 "\n"
-"    • 下のモジュールは自身より下にモジュールを持つことができません。\n"
-"    • 下のモジュールは入れ替え後に上のスペースに納まりきらない場合がありま"
-"す。\n"
-"    • このモジュールが入れ替え後に下のスペースに納まりきらない場合がありま"
-"す。"
+"    • 直下のモジュールは自身より下にモジュールを持つことができない。\n"
+"    • 直下のモジュールが入れ替え後の上部空間に納まりきらない。\n"
+"    • このモジュールが入れ替え後の下部空間に納まりきらない。"
 
 #. STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.BUTTONSWAPMODULEUP.DESC
 msgctxt ""
 "STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.BUTTONSWAPMODULEUP.DESC"
 msgid "Swap this rocket module with the one above"
-msgstr "上のモジュールと入れ替えます"
+msgstr "このモジュールを直上にあるモジュールと入れ替えます"
 
 #. STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.BUTTONSWAPMODULEUP.INVALID
 msgctxt ""
@@ -26147,13 +26145,11 @@ msgid ""
 "    • A module above may be unable to fit into the space below it.\n"
 "    • This module may be unable to fit into the space above it."
 msgstr ""
-"入れ替え可能なモジュールがありません。\n"
+"直上のモジュールと入れ替えることはできません。理由は次のいずれかです。\n"
 "\n"
-"    • 上のモジュールは自身より上にモジュールを持つことができません。\n"
-"    • 上のモジュールは入れ替え後に下のスペースに納まりきらない場合がありま"
-"す。\n"
-"    • このモジュールが入れ替え後に上のスペースに納まりきらない場合がありま"
-"す。"
+"    • 直上のモジュールは自身より上にモジュールを持つことができない。\n"
+"    • 直上のモジュールが入れ替え後の下部空間に納まりきらない。\n"
+"    • このモジュールが入れ替え後の上部空間に納まりきらない。"
 
 #. STRINGS.UI.UISIDESCREENS.ROCKETMODULESIDESCREEN.BUTTONVIEWEXTERIOR.DESC
 msgctxt ""
@@ -26276,16 +26272,16 @@ msgid ""
 "Buildings with their access restricted cannot be operated, though they can "
 "still be filled"
 msgstr ""
-"設備制限は自動化によって管理されています\n"
+"ロケット内設備の使用規制は自動化信号によって制御されています\n"
 "\n"
-"アクセス制限された設備は積み込みは行えますが操作はできません"
+"規制中の設備は使用できません (内容物の収納は可能です)"
 
 #. STRINGS.UI.UISIDESCREENS.ROCKETRESTRICTIONSIDESCREEN.BUILDING_RESTRICTIONS_LABEL
 msgctxt ""
 "STRINGS.UI.UISIDESCREENS.ROCKETRESTRICTIONSIDESCREEN."
 "BUILDING_RESTRICTIONS_LABEL"
 msgid "Interior Building Restrictions"
-msgstr "内装設備制限"
+msgstr "ロケット内設備の使用規制"
 
 #. STRINGS.UI.UISIDESCREENS.ROCKETRESTRICTIONSIDESCREEN.GROUNDED_RESTRICTION_BUTTON
 msgctxt ""
@@ -26301,7 +26297,7 @@ msgctxt ""
 msgid ""
 "Buildings with their access restricted cannot be operated while grounded, "
 "though they can still be filled"
-msgstr "アクセス制限された設備は積み込みは行えますが着陸中は操作はできません"
+msgstr "着陸中は規制された設備を使用できません (内容物の収納は可能です)"
 
 #. STRINGS.UI.UISIDESCREENS.ROCKETRESTRICTIONSIDESCREEN.NONE_RESTRICTION_BUTTON
 msgctxt ""
@@ -26314,7 +26310,7 @@ msgctxt ""
 "STRINGS.UI.UISIDESCREENS.ROCKETRESTRICTIONSIDESCREEN."
 "NONE_RESTRICTION_BUTTON_TOOLTIP"
 msgid "There are no restrictions on buildings inside this rocket"
-msgstr "このロケット内に制限可能な設備はありません"
+msgstr "このロケットの内部では設備の使用を規制しません"
 
 #. STRINGS.UI.UISIDESCREENS.ROCKETRESTRICTIONSIDESCREEN.TITLE
 msgctxt "STRINGS.UI.UISIDESCREENS.ROCKETRESTRICTIONSIDESCREEN.TITLE"
@@ -28755,12 +28751,12 @@ msgstr "移設指示を取り消します"
 #. STRINGS.UI.USERMENUACTIONS.ROCKETUSAGERESTRICTION.NAME_CONTROLLED
 msgctxt "STRINGS.UI.USERMENUACTIONS.ROCKETUSAGERESTRICTION.NAME_CONTROLLED"
 msgid "Controlled"
-msgstr "制御中"
+msgstr "制御する"
 
 #. STRINGS.UI.USERMENUACTIONS.ROCKETUSAGERESTRICTION.NAME_UNCONTROLLED
 msgctxt "STRINGS.UI.USERMENUACTIONS.ROCKETUSAGERESTRICTION.NAME_UNCONTROLLED"
 msgid "Uncontrolled"
-msgstr "制御なし"
+msgstr "制御をやめる"
 
 #. STRINGS.UI.USERMENUACTIONS.ROCKETUSAGERESTRICTION.TOOLTIP_CONTROLLED
 msgctxt "STRINGS.UI.USERMENUACTIONS.ROCKETUSAGERESTRICTION.TOOLTIP_CONTROLLED"
@@ -28768,8 +28764,8 @@ msgid ""
 "Allow this building's operation to be controlled by a "
 "<link=\"ROCKETCONTROLSTATION\">Rocket Control Station</link>"
 msgstr ""
-"この設備の操作を<link=\"ROCKETCONTROLSTATION\">ロケット制御端末</link>に任せ"
-"ます"
+"この設備を<link=\"ROCKETCONTROLSTATION\">ロケット制御端末</link>による使用規"
+"制に従わせます"
 
 #. STRINGS.UI.USERMENUACTIONS.ROCKETUSAGERESTRICTION.TOOLTIP_UNCONTROLLED
 msgctxt ""
@@ -28778,8 +28774,8 @@ msgid ""
 "Do not allow this building to be controlled by a "
 "<link=\"ROCKETCONTROLSTATION\">Rocket Control Station</link>"
 msgstr ""
-"この設備の操作を<link=\"ROCKETCONTROLSTATION\">ロケット制御端末</link>に任せ"
-"ません"
+"この設備に<link=\"ROCKETCONTROLSTATION\">ロケット制御端末</link>による使用規"
+"制を無視させます"
 
 #. STRINGS.UI.USERMENUACTIONS.SELECTRESEARCH.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.SELECTRESEARCH.NAME"


### PR DESCRIPTION
以前に採用された翻訳 dbd9171 が元に戻っていることに気付いたため、改めて翻訳しました。
次の本体アップデートに対応した際に戻ってしまったようです。
（明らかな誤訳も復活していたため、意図的なロールバックではないと判断しました）

表題どおり、ロケット制御端末など宇宙関連施設の訳が中心です。

ロケット制御端末による設備の無効化(`Restriction`)は、今回`規制`と訳しています。
個人的な感覚かもしれませんが、`制限`だと、限定的な使用は可能といった一部肯定的な意味合いも感じられてしまい、誤解を招く気がしたので、より禁止の意味が強い`規制`としました。

そのほか、ロケット建造時のUIの説明文を、実際の挙動に沿うよう、より分かりやすくしています。

ご確認をお願いします。