### PR TITLE
眼の炎症に関する説明文

### DIFF
--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -6449,12 +6449,12 @@ msgstr ""
 #. STRINGS.DUPLICANTS.MODIFIERS.MAJORIRRITATION.CAUSE
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MAJORIRRITATION.CAUSE"
 msgid "Obtained by exposure to a harsh liquid or gas"
-msgstr "刺激性の高い液体または気体に触れたため付与"
+msgstr "刺激性の高い液体または気体に曝露したため発生"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.MAJORIRRITATION.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MAJORIRRITATION.NAME"
 msgid "Major Eye Irritation"
-msgstr "重篤な眼刺激"
+msgstr "重篤な眼の炎症"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.MAJORIRRITATION.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MAJORIRRITATION.TOOLTIP"
@@ -6463,9 +6463,9 @@ msgid ""
 "\n"
 "Caused by exposure to a harsh liquid or gas"
 msgstr ""
-"うわっ、何かがこの複製人間の眼を台無しにしてしまいました！\n"
+"うわっ、この複製人間の眼は本当にめちゃくちゃな状態だ！\n"
 "\n"
-"刺激性の液体または気体に曝露しました"
+"刺激性の液体または気体に曝露したため発生"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.MANAGEDCOLONY.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MANAGEDCOLONY.NAME"
@@ -6526,12 +6526,12 @@ msgstr "医療ベッドは複製人間の怪我の快復速度を劇的に上昇
 #. STRINGS.DUPLICANTS.MODIFIERS.MEDICALCOTDOCTORED.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MEDICALCOTDOCTORED.NAME"
 msgid "Receiving treatment"
-msgstr "手当てを受けています"
+msgstr "手当てを受けている"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.MEDICALCOTDOCTORED.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MEDICALCOTDOCTORED.TOOLTIP"
 msgid "This Duplicant is receiving treatment for their physical injuries"
-msgstr "この複製人間は負傷のため手当を受けています"
+msgstr "この複製人間の負傷には手当てがされています"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.MEDICINE_BASICBOOSTER.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MEDICINE_BASICBOOSTER.NAME"
@@ -6638,17 +6638,17 @@ msgstr ""
 #. STRINGS.DUPLICANTS.MODIFIERS.MINORIRRITATION.CAUSE
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MINORIRRITATION.CAUSE"
 msgid "Obtained by exposure to a harsh liquid or gas"
-msgstr "刺激性の高い液体または気体に触れたため付与"
+msgstr "刺激性の高い液体または気体に曝露したため発生"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.MINORIRRITATION.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MINORIRRITATION.NAME"
 msgid "Minor Eye Irritation"
-msgstr "軽微な眼刺激"
+msgstr "軽微な眼の炎症"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.MINORIRRITATION.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MINORIRRITATION.TOOLTIP"
 msgid "A gas or liquid made this Duplicant's eyes sting a little"
-msgstr "気体または液体がこの複製人間の眼に刺激を引き起こしています"
+msgstr "気体または液体がこの複製人間の眼に軽微な炎症を引き起こしています"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.MODERATEWOUNDS.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MODERATEWOUNDS.NAME"
@@ -10224,12 +10224,12 @@ msgstr ""
 #. STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.NAME_MAJOR
 msgctxt "STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.NAME_MAJOR"
 msgid "Major Eye Irritation"
-msgstr "重篤な眼刺激"
+msgstr "重篤な眼の炎症"
 
 #. STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.NAME_MINOR
 msgctxt "STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.NAME_MINOR"
 msgid "Eye Irritation"
-msgstr "眼刺激"
+msgstr "眼の炎症"
 
 #. STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.TOOLTIP"
@@ -10238,14 +10238,14 @@ msgid ""
 "\n"
 "This poor Duplicant got a faceful of an irritating gas or liquid"
 msgstr ""
-"あっ、痛っ！\n"
+"あぁ、目がしみる！\n"
 "\n"
-"この可哀相な複製人間は刺激性の気体または液体を顔じゅうに浴びてしまいました"
+"この哀れな複製人間は刺激性の気体または液体を顔じゅうに浴びてしまいました"
 
 #. STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.TOOLTIP_EXPOSED
 msgctxt "STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.TOOLTIP_EXPOSED"
 msgid "Current exposure to {element} is {rate} eye irritation"
-msgstr "{element}への曝露は{rate}眼刺激を引き起こします"
+msgstr "現在、{element}への曝露により目の炎症{rate}"
 
 #. STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.TOOLTIP_EXPOSURE_LEVEL
 msgctxt ""
@@ -10257,18 +10257,18 @@ msgstr "残り時間: {time}"
 msgctxt ""
 "STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.TOOLTIP_RATE_DECREASE"
 msgid "decreasing"
-msgstr "減少中"
+msgstr "は快復中です"
 
 #. STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.TOOLTIP_RATE_INCREASE
 msgctxt ""
 "STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.TOOLTIP_RATE_INCREASE"
 msgid "increasing"
-msgstr "上昇中"
+msgstr "が悪化中です"
 
 #. STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.TOOLTIP_RATE_STAYS
 msgctxt "STRINGS.DUPLICANTS.STATUSITEMS.GASLIQUIDEXPOSURE.TOOLTIP_RATE_STAYS"
 msgid "maintaining"
-msgstr "現状維持"
+msgstr "は現状維持されます"
 
 #. STRINGS.DUPLICANTS.STATUSITEMS.GENERATINGPOWER.NAME
 msgctxt "STRINGS.DUPLICANTS.STATUSITEMS.GENERATINGPOWER.NAME"
@@ -14133,27 +14133,27 @@ msgstr "バイオハザード"
 
 #~ msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MAJORIRRITATION.NAME"
 #~ msgid "Major Skin Irritation"
-#~ msgstr "重篤な皮膚刺激"
+#~ msgstr "重篤な皮膚炎"
 
 #~ msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MINORIRRITATION.NAME"
 #~ msgid "Minor Skin Irritation"
-#~ msgstr "軽微な皮膚刺激"
+#~ msgstr "軽微な皮膚炎"
 
 #~ msgctxt "STRINGS.DUPLICANTS.MODIFIERS.RADIATIONEXPOSUREEXTREME.TOOLTIP"
 #~ msgid "Extreme Radiation exposure is hurting this Duplicant"
-#~ msgstr "強烈な放射線被ばくがこの複製人間を蝕んでいます"
+#~ msgstr "強烈な放射線被曝がこの複製人間を蝕んでいます"
 
 #~ msgctxt "STRINGS.DUPLICANTS.MODIFIERS.RADIATIONEXPOSUREMAJOR.TOOLTIP"
 #~ msgid ""
 #~ "Previous large-scale Radiation exposure is making this Duplicant very "
 #~ "tired"
-#~ msgstr "以前受けた大規模な放射線被ばくがこの複製人間を疲弊さえています"
+#~ msgstr "以前受けた大規模な放射線被曝がこの複製人間を疲弊さえています"
 
 #~ msgctxt "STRINGS.DUPLICANTS.MODIFIERS.RADIATIONEXPOSUREMINOR.TOOLTIP"
 #~ msgid ""
 #~ "Previous small-scale Radiation exposure is making this Duplicant slightly "
 #~ "tired"
-#~ msgstr "以前受けた小規模な放射線被ばくがこの複製人間を気だるくしています"
+#~ msgstr "以前受けた小規模な放射線被曝がこの複製人間を気だるくしています"
 
 #~ msgctxt "STRINGS.DUPLICANTS.ROLES.THERMAL_SUIT_WEARER.DESCRIPTION"
 #~ msgid "Work in progress skill"


### PR DESCRIPTION
`塩素`ガスや`濃塩水`などに浸かると複製人間に発生する`Eye Irritation`の説明文に、少し変なところがあったので修正しました。全体的に関連しそうな箇所を見直して、文言を統一しています。（`Eye Irritation`の訳は`眼刺激`から`眼の炎症`に変更しました。）

`Receiving treatment`は、負傷が手当て済みであることを示すステータスなので、ツールチップの説明文をより明確にしました。

確認をお願いいたします。