### PR TITLE
眼の炎症に関する説明文（再）

### DIFF
--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -6449,7 +6449,7 @@ msgstr ""
 #. STRINGS.DUPLICANTS.MODIFIERS.MAJORIRRITATION.CAUSE
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MAJORIRRITATION.CAUSE"
 msgid "Obtained by exposure to a harsh liquid or gas"
-msgstr "刺激性の高い液体または気体に曝露したため発生"
+msgstr "刺激性の液体または気体に曝露したため発生"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.MAJORIRRITATION.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MAJORIRRITATION.NAME"
@@ -6638,7 +6638,7 @@ msgstr ""
 #. STRINGS.DUPLICANTS.MODIFIERS.MINORIRRITATION.CAUSE
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MINORIRRITATION.CAUSE"
 msgid "Obtained by exposure to a harsh liquid or gas"
-msgstr "刺激性の高い液体または気体に曝露したため発生"
+msgstr "刺激性の液体または気体に曝露したため発生"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.MINORIRRITATION.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MINORIRRITATION.NAME"
@@ -14147,7 +14147,7 @@ msgstr "バイオハザード"
 #~ msgid ""
 #~ "Previous large-scale Radiation exposure is making this Duplicant very "
 #~ "tired"
-#~ msgstr "以前受けた大規模な放射線被曝がこの複製人間を疲弊さえています"
+#~ msgstr "以前受けた大規模な放射線被曝がこの複製人間を疲弊させています"
 
 #~ msgctxt "STRINGS.DUPLICANTS.MODIFIERS.RADIATIONEXPOSUREMINOR.TOOLTIP"
 #~ msgid ""


### PR DESCRIPTION
マージありがとうございます。
非常に細かいのですが、文言の統一に見落としがあったので再修正してリクエストします。

"by exposure to a harsh liquid or gas"の訳に
"刺激性の**高い**液体または気体に曝露したため"
"刺激性の液体または気体に曝露したため"
の揺れがあったので、統一しました。

"疲弊さえています"は既に修正してしまって、わざわざ元に戻すのも何なのでそのままです。

二度手間で大変申し訳ありません。
よろしくお願いします。