### PR TITLE
ITEMS翻訳

### DIFF
--- a/po/items.po
+++ b/po/items.po
@@ -47,7 +47,7 @@ msgstr "ロケットの残骸"
 #| msgid "Unrefrigerated Food"
 msgctxt "STRINGS.ITEMS.DEHYDRATEDFOODPACKAGE.CONSUMED"
 msgid "Ate Rehydrated Food"
-msgstr "冷蔵されていない食糧"
+msgstr "水で戻した食糧を食べた"
 
 #. STRINGS.ITEMS.DEHYDRATEDFOODPACKAGE.CONTENTS
 #, fuzzy
@@ -55,7 +55,7 @@ msgstr "冷蔵されていない食糧"
 #| msgid "Displayed {0}"
 msgctxt "STRINGS.ITEMS.DEHYDRATEDFOODPACKAGE.CONTENTS"
 msgid "Dried {0}"
-msgstr "{0} 展示中"
+msgstr "乾燥{0}"
 
 #. STRINGS.ITEMS.DEHYDRATEDFOODPACKAGE.DESC
 msgctxt "STRINGS.ITEMS.DEHYDRATEDFOODPACKAGE.DESC"
@@ -64,6 +64,9 @@ msgid ""
 "\n"
 "It requires no refrigeration, but must be rehydrated before consumption."
 msgstr ""
+"腐りにくい乾燥食糧のパックです。\n"
+"\n"
+"冷凍を必要としませんが、摂取する前に水で戻さなければなりません。"
 
 #. STRINGS.ITEMS.DEHYDRATEDFOODPACKAGE.NAME
 #, fuzzy
@@ -71,7 +74,7 @@ msgstr ""
 #| msgid "Joy Reaction"
 msgctxt "STRINGS.ITEMS.DEHYDRATEDFOODPACKAGE.NAME"
 msgid "Dry Ration"
-msgstr "歓喜反応"
+msgstr "乾燥レーション"
 
 #. STRINGS.ITEMS.DREAMJOURNAL.DESC
 msgctxt "STRINGS.ITEMS.DREAMJOURNAL.DESC"
@@ -176,11 +179,15 @@ msgid ""
 "\n"
 "Dry rations have no expiry date."
 msgstr ""
+"<link=\"BERRYPIE\">ミックスベリーパイ</link>の乾燥レーションです。"
+"<link=\"FOOD\">食糧</link>として扱うには水で戻す必要があります。\n"
+"\n"
+"乾燥レーションは賞味期限がありません。"
 
 #. STRINGS.ITEMS.FOOD.BERRYPIE.DEHYDRATED.NAME
 msgctxt "STRINGS.ITEMS.FOOD.BERRYPIE.DEHYDRATED.NAME"
 msgid "Dried Berry Pie"
-msgstr ""
+msgstr "乾燥ベリーパイ"
 
 #. STRINGS.ITEMS.FOOD.BERRYPIE.DESC
 msgctxt "STRINGS.ITEMS.FOOD.BERRYPIE.DESC"
@@ -219,11 +226,15 @@ msgid ""
 "\n"
 "Dry rations have no expiry date."
 msgstr ""
+"<link=\"BURGER\">ひんやりバーガー</link>の乾燥レーションです。"
+"<link=\"FOOD\">食糧</link>として扱うには水で戻す必要があります。\n"
+"\n"
+"乾燥レーションは賞味期限がありません。"
 
 #. STRINGS.ITEMS.FOOD.BURGER.DEHYDRATED.NAME
 msgctxt "STRINGS.ITEMS.FOOD.BURGER.DEHYDRATED.NAME"
 msgid "Dried Frost Burger"
-msgstr ""
+msgstr "乾燥ひんやりバーガー"
 
 #. STRINGS.ITEMS.FOOD.BURGER.DESC
 msgctxt "STRINGS.ITEMS.FOOD.BURGER.DESC"
@@ -363,11 +374,15 @@ msgid ""
 "\n"
 "Dry rations have no expiry date."
 msgstr ""
+"<link=\"BERRYPIE\">豆のカレー煮込み</link>の乾燥レーションです。"
+"<link=\"FOOD\">食糧</link>として扱うには水で戻す必要があります。\n"
+"\n"
+"乾燥レーションは賞味期限がありません。"
 
 #. STRINGS.ITEMS.FOOD.CURRY.DEHYDRATED.NAME
 msgctxt "STRINGS.ITEMS.FOOD.CURRY.DEHYDRATED.NAME"
 msgid "Dried Curried Beans"
-msgstr ""
+msgstr "乾燥カレー煮込み"
 
 #. STRINGS.ITEMS.FOOD.CURRY.DESC
 msgctxt "STRINGS.ITEMS.FOOD.CURRY.DESC"
@@ -724,11 +739,15 @@ msgid ""
 "\n"
 "Dry rations have no expiry date."
 msgstr ""
+"<link=\"MUSHROOMWRAP\">キノコのレタス包み</link>の乾燥レーションです。"
+"<link=\"FOOD\">食糧</link>として扱うには水で戻す必要があります。\n"
+"\n"
+"乾燥レーションは賞味期限がありません。"
 
 #. STRINGS.ITEMS.FOOD.MUSHROOMWRAP.DEHYDRATED.NAME
 msgctxt "STRINGS.ITEMS.FOOD.MUSHROOMWRAP.DEHYDRATED.NAME"
 msgid "Dried Mushroom Wrap"
-msgstr ""
+msgstr "乾燥レタス包み"
 
 #. STRINGS.ITEMS.FOOD.MUSHROOMWRAP.DESC
 msgctxt "STRINGS.ITEMS.FOOD.MUSHROOMWRAP.DESC"
@@ -917,11 +936,15 @@ msgid ""
 "\n"
 "Dry rations have no expiry date."
 msgstr ""
+"<link=\"QUICHE\">キノコキッシュ</link>の乾燥レーションです。"
+"<link=\"FOOD\">食糧</link>として扱うには水で戻す必要があります。\n"
+"\n"
+"乾燥レーションは賞味期限がありません。"
 
 #. STRINGS.ITEMS.FOOD.QUICHE.DEHYDRATED.NAME
 msgctxt "STRINGS.ITEMS.FOOD.QUICHE.DEHYDRATED.NAME"
 msgid "Dried Mushroom Quiche"
-msgstr ""
+msgstr "乾燥キノコキッシュ"
 
 #. STRINGS.ITEMS.FOOD.QUICHE.DESC
 msgctxt "STRINGS.ITEMS.FOOD.QUICHE.DESC"
@@ -999,11 +1022,15 @@ msgid ""
 "\n"
 "Dry rations have no expiry date."
 msgstr ""
+"<link=\"SALSA\">どろどろベリー</link>の乾燥レーションです。"
+"<link=\"FOOD\">食糧</link>として扱うには水で戻す必要があります。\n"
+"\n"
+"乾燥レーションは賞味期限がありません。"
 
 #. STRINGS.ITEMS.FOOD.SALSA.DEHYDRATED.NAME
 msgctxt "STRINGS.ITEMS.FOOD.SALSA.DEHYDRATED.NAME"
 msgid "Dried Stuffed Berry"
-msgstr ""
+msgstr "乾燥どろどろベリー"
 
 #. STRINGS.ITEMS.FOOD.SALSA.DESC
 msgctxt "STRINGS.ITEMS.FOOD.SALSA.DESC"
@@ -1050,11 +1077,15 @@ msgid ""
 "\n"
 "Dry rations have no expiry date."
 msgstr ""
+"<link=\"SPICEBREAD\">ペッパーブレッド</link>の乾燥レーションです。"
+"<link=\"FOOD\">食糧</link>として扱うには水で戻す必要があります。\n"
+"\n"
+"乾燥レーションは賞味期限がありません。"
 
 #. STRINGS.ITEMS.FOOD.SPICEBREAD.DEHYDRATED.NAME
 msgctxt "STRINGS.ITEMS.FOOD.SPICEBREAD.DEHYDRATED.NAME"
 msgid "Dried Pepper Bread"
-msgstr ""
+msgstr "乾燥ペッパーブレッド"
 
 #. STRINGS.ITEMS.FOOD.SPICEBREAD.DESC
 msgctxt "STRINGS.ITEMS.FOOD.SPICEBREAD.DESC"
@@ -1107,11 +1138,15 @@ msgid ""
 "\n"
 "Dry rations have no expiry date."
 msgstr ""
+"<link=\"SPICYTOFU\">ピリ辛豆腐</link>の乾燥レーションです。"
+"<link=\"FOOD\">食糧</link>として扱うには水で戻す必要があります。\n"
+"\n"
+"乾燥レーションは賞味期限がありません。"
 
 #. STRINGS.ITEMS.FOOD.SPICYTOFU.DEHYDRATED.NAME
 msgctxt "STRINGS.ITEMS.FOOD.SPICYTOFU.DEHYDRATED.NAME"
 msgid "Dried Spicy Tofu"
-msgstr ""
+msgstr "乾燥ピリ辛豆腐"
 
 #. STRINGS.ITEMS.FOOD.SPICYTOFU.DESC
 msgctxt "STRINGS.ITEMS.FOOD.SPICYTOFU.DESC"
@@ -1148,11 +1183,15 @@ msgid ""
 "\n"
 "Dry rations have no expiry date."
 msgstr ""
+"<link=\"SURFANDTURF\">サーフ・アンド・ターフ</link>の乾燥レーションです。"
+"<link=\"FOOD\">食糧</link>として扱うには水で戻す必要があります。\n"
+"\n"
+"乾燥レーションは賞味期限がありません。"
 
 #. STRINGS.ITEMS.FOOD.SURFANDTURF.DEHYDRATED.NAME
 msgctxt "STRINGS.ITEMS.FOOD.SURFANDTURF.DEHYDRATED.NAME"
 msgid "Dried Surf'n'Turf"
-msgstr ""
+msgstr "乾燥サーフ・アンド・ターフ"
 
 #. STRINGS.ITEMS.FOOD.SURFANDTURF.DESC
 msgctxt "STRINGS.ITEMS.FOOD.SURFANDTURF.DESC"


### PR DESCRIPTION
乾燥レーションについて一部省略を入れました。
豆のカレー煮込み → 乾燥カレー煮込み
キノコのレタス包み → 乾燥レタス包み

`乾燥豆のカレー煮込み`にしてしまうと乾燥豆が一塊で、原料に乾燥豆を使ったカレー煮込みになってしまうので、あえて省略しています。