### PR TITLE
死者の追悼（墓参りの作業）

### DIFF
--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -2568,15 +2568,18 @@ msgctxt "STRINGS.DUPLICANTS.CHORES.MOURN.NAME"
 msgid "Mourn"
 msgstr "追悼"
 
+# 複製人間のステータス欄に表示される状態名です。
+# 原文は"STRINGS.DUPLICANTS.MODIFIERS.MOURNING.NAME"と同じですが、「追悼」の作業をしている間しか表示されないため「追悼中」としています。（作業名 + "中"）
 #. STRINGS.DUPLICANTS.CHORES.MOURN.STATUS
 msgctxt "STRINGS.DUPLICANTS.CHORES.MOURN.STATUS"
 msgid "Mourning"
 msgstr "追悼中"
 
+# 構文は"STRINGS.DUPLICANTS.MODIFIERS.MOURNING.TOOLTIP"とほぼ同じですが、「作業」の説明なので、能動的な表現にしています。
 #. STRINGS.DUPLICANTS.CHORES.MOURN.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.CHORES.MOURN.TOOLTIP"
 msgid "This Duplicant is mourning the loss of a friend"
-msgstr "この複製人間は友人を亡くして悲しんでいます"
+msgstr "この複製人間は友人の死を悼んでいます"
 
 #. STRINGS.DUPLICANTS.CHORES.MOVETO.NAME
 msgctxt "STRINGS.DUPLICANTS.CHORES.MOVETO.NAME"
@@ -6761,15 +6764,18 @@ msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MODIFIER_FORMAT"
 msgid "<style=\"KKeyword\">{0}</style>: {1}"
 msgstr "<style=\"KKeyword\">{0}</style>: <b>{1}</b>"
 
+# 複製人間のステータス欄に表示される状態名です。
+# 原文は"STRINGS.DUPLICANTS.CHORES.MOURN.STATUS"と同じですが、仲間の複製人間が死亡してから数日のあいだ持続するため「喪中」としています。
 #. STRINGS.DUPLICANTS.MODIFIERS.MOURNING.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MOURNING.NAME"
 msgid "Mourning"
 msgstr "喪中"
 
+# 構文は"STRINGS.DUPLICANTS.CHORES.MOURN.TOOLTIP"とほぼ同じですが、「状態」の説明なので、受動的な表現にしています。
 #. STRINGS.DUPLICANTS.MODIFIERS.MOURNING.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MOURNING.TOOLTIP"
 msgid "This Duplicant is grieving the loss of a friend"
-msgstr "この複製人間は友人を亡くして悲しんでいます"
+msgstr "この複製人間は友人を亡くして悲嘆に暮れています"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.NARCOLEPTICSLEEP.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.NARCOLEPTICSLEEP.NAME"

--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -2566,17 +2566,17 @@ msgstr ""
 #. STRINGS.DUPLICANTS.CHORES.MOURN.NAME
 msgctxt "STRINGS.DUPLICANTS.CHORES.MOURN.NAME"
 msgid "Mourn"
-msgstr "喪中"
+msgstr "追悼"
 
 #. STRINGS.DUPLICANTS.CHORES.MOURN.STATUS
 msgctxt "STRINGS.DUPLICANTS.CHORES.MOURN.STATUS"
 msgid "Mourning"
-msgstr "喪中"
+msgstr "追悼中"
 
 #. STRINGS.DUPLICANTS.CHORES.MOURN.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.CHORES.MOURN.TOOLTIP"
 msgid "This Duplicant is mourning the loss of a friend"
-msgstr "この複製人間は友の喪失で悲嘆にくれています"
+msgstr "この複製人間は友人を亡くして悲しんでいます"
 
 #. STRINGS.DUPLICANTS.CHORES.MOVETO.NAME
 msgctxt "STRINGS.DUPLICANTS.CHORES.MOVETO.NAME"
@@ -3085,7 +3085,7 @@ msgstr "治療可能な病気なし"
 #. STRINGS.DUPLICANTS.CHORES.PRECONDITIONS.VALID_MOURNING_SITE
 msgctxt "STRINGS.DUPLICANTS.CHORES.PRECONDITIONS.VALID_MOURNING_SITE"
 msgid "Nowhere to mourn"
-msgstr "喪に服していない"
+msgstr "追悼する場所がない"
 
 #. STRINGS.DUPLICANTS.CHORES.PROCESSCRITTER.NAME
 msgctxt "STRINGS.DUPLICANTS.CHORES.PROCESSCRITTER.NAME"
@@ -6764,12 +6764,12 @@ msgstr "<style=\"KKeyword\">{0}</style>: <b>{1}</b>"
 #. STRINGS.DUPLICANTS.MODIFIERS.MOURNING.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MOURNING.NAME"
 msgid "Mourning"
-msgstr "死に嘆いている"
+msgstr "喪中"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.MOURNING.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.MOURNING.TOOLTIP"
 msgid "This Duplicant is grieving the loss of a friend"
-msgstr "この複製人間は友の喪失に嘆いています"
+msgstr "この複製人間は友人を亡くして悲しんでいます"
 
 #. STRINGS.DUPLICANTS.MODIFIERS.NARCOLEPTICSLEEP.NAME
 msgctxt "STRINGS.DUPLICANTS.MODIFIERS.NARCOLEPTICSLEEP.NAME"


### PR DESCRIPTION
死んだ複製人間を``シックな墓標``に埋葬すると、ほかの複製人間が墓参りすることがあります。
それらに関連した訳文を整理してみました。

- ``STRINGS.DUPLICANTS.CHORES.MOURN.NAME``
``Mourn`` → ``追悼``
作業名です。仲間が葬られた墓標の前で嘆き悲しみます。
複製人間を選択した際の作業一覧（優先度順に並ぶやつ）に表示されます。
- ``STRINGS.DUPLICANTS.CHORES.MOURN.STATUS``
``Mourning`` → ``追悼中``
複製人間のステータス窓に箇条書きにされる状態名です。``追悼``の作業をしている間**だけ**表示されます。
- ``STRINGS.DUPLICANTS.MODIFIERS.MOURNING.NAME``
``Mourning`` → ``喪中``
複製人間のステータス窓に箇条書きにされる状態名です。仲間が死亡してから**一定期間**持続します。
おそらくこの期間中に、``追悼``の作業が発生するものと思われます。
原文は前項と同一ですが、条件の違いを汲んで訳し分けてみました。

よろしくお願いします。