### PR TITLE
Fix a wrong sentence

### DIFF
--- a/po/ui.po
+++ b/po/ui.po
@@ -1166,7 +1166,7 @@ msgid ""
 msgstr ""
 "この間欠泉は活動期の間、平均{average}の{element}が湧き出します\n"
 "\n"
-"この効果は休眠期間を増加させます"
+"これは休眠期間を含んでいます"
 
 #. STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.GEYSER_YEAR_AVR_OUTPUT_BREAKDOWN_ROW
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.GEYSER_YEAR_AVR_OUTPUT_BREAKDOWN_ROW"

--- a/po/ui.po
+++ b/po/ui.po
@@ -1164,7 +1164,7 @@ msgid ""
 "\n"
 "This includes its dormant period"
 msgstr ""
-"この間欠泉は活動期の間、平均{average}の{element}が湧き出します\n"
+"この間欠泉はその存続期間において、平均{average}の{element}が湧き出します\n"
 "\n"
 "これは休眠期間を含んでいます"
 


### PR DESCRIPTION
![](https://i.gyazo.com/e970f4e279d5ae1805cf9c45b457ea55.png)

ゲームをプレイしている上で、あれ? となったので確認したところ

```
msgid ""
"This geyser emits an average of {average} of {element} during its lifetime\n"
"\n"
"This includes its dormant period"
msgstr ""
"この間欠泉は活動期の間、平均{average}の{element}が湧き出します\n"
"\n"
"この効果は休眠期間を増加させます"
```

たぶんこれは休眠期間を含んだ全体の平均を示しているはずだな、と推測しました。というわけでそのように修正してみました!