### PR TITLE
小惑星特性の訳

### DIFF
--- a/po/creatures.po
+++ b/po/creatures.po
@@ -1727,7 +1727,7 @@ msgstr "<link=\"GEYSER\">蒸気間欠泉</link>"
 #. STRINGS.CREATURES.SPECIES.GEYSER.OIL_DRIP.DESC
 msgctxt "STRINGS.CREATURES.SPECIES.GEYSER.OIL_DRIP.DESC"
 msgid "A fissure that periodically erupts with boiling <link=\"CRUDEOIL\">Crude Oil</link>."
-msgstr "定期的に熱い<link=\"CRUDEOIL\">原油</link>を噴き上げる、隕石内の漏出孔です。"
+msgstr "定期的に熱い<link=\"CRUDEOIL\">原油</link>を噴き上げる漏出孔です。"
 
 #. STRINGS.CREATURES.SPECIES.GEYSER.OIL_DRIP.NAME
 msgctxt "STRINGS.CREATURES.SPECIES.GEYSER.OIL_DRIP.NAME"

--- a/po/world_traits.po
+++ b/po/world_traits.po
@@ -15,7 +15,7 @@ msgstr ""
 #. STRINGS.WORLD_TRAITS.BOULDERS_LARGE.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.BOULDERS_LARGE.DESCRIPTION"
 msgid "Huge boulders make digging through this world more difficult"
-msgstr "巨大な岩塊がこの小惑星の採掘をより困難にしています"
+msgstr "巨大な岩塊があるせいで、この小惑星の採掘は一段と困難です"
 
 #. STRINGS.WORLD_TRAITS.BOULDERS_LARGE.NAME
 msgctxt "STRINGS.WORLD_TRAITS.BOULDERS_LARGE.NAME"
@@ -25,17 +25,17 @@ msgstr "巨大な岩塊"
 #. STRINGS.WORLD_TRAITS.BOULDERS_MEDIUM.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.BOULDERS_MEDIUM.DESCRIPTION"
 msgid "Mid-sized boulders make digging through this world more difficult"
-msgstr "中程度の岩塊がこの小惑星の採掘をより困難にしています"
+msgstr "中規模の岩塊があるせいで、この小惑星の採掘は一段と困難です"
 
 #. STRINGS.WORLD_TRAITS.BOULDERS_MEDIUM.NAME
 msgctxt "STRINGS.WORLD_TRAITS.BOULDERS_MEDIUM.NAME"
 msgid "Medium Boulders"
-msgstr "中程度の岩塊"
+msgstr "中規模の岩塊"
 
 #. STRINGS.WORLD_TRAITS.BOULDERS_MIXED.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.BOULDERS_MIXED.DESCRIPTION"
 msgid "Boulders of various sizes make digging through this world more difficult"
-msgstr "大小様々な岩塊がこの小惑星の採掘を困難にしています"
+msgstr "大小様々な岩塊があるせいで、この小惑星の採掘は一段と困難です"
 
 #. STRINGS.WORLD_TRAITS.BOULDERS_MIXED.NAME
 msgctxt "STRINGS.WORLD_TRAITS.BOULDERS_MIXED.NAME"
@@ -45,7 +45,7 @@ msgstr "大小様々な岩塊"
 #. STRINGS.WORLD_TRAITS.BOULDERS_SMALL.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.BOULDERS_SMALL.DESCRIPTION"
 msgid "Tiny boulders make digging through this world more difficult"
-msgstr "小さな岩塊がこの小惑星の採掘をより困難にしています"
+msgstr "小さな岩塊があるせいで、この小惑星の採掘は一段と困難です"
 
 #. STRINGS.WORLD_TRAITS.BOULDERS_SMALL.NAME
 msgctxt "STRINGS.WORLD_TRAITS.BOULDERS_SMALL.NAME"
@@ -55,7 +55,7 @@ msgstr "小さな岩塊"
 #. STRINGS.WORLD_TRAITS.CRASHED_SATELLITES.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.CRASHED_SATELLITES.DESCRIPTION"
 msgid "This world contains crashed radioactive satellites"
-msgstr "この惑星には墜落した放射性の人工衛星があります"
+msgstr "この小惑星には墜落した放射性の人工衛星があります"
 
 #. STRINGS.WORLD_TRAITS.CRASHED_SATELLITES.NAME
 msgctxt "STRINGS.WORLD_TRAITS.CRASHED_SATELLITES.NAME"
@@ -65,7 +65,7 @@ msgstr "墜落した人工衛星"
 #. STRINGS.WORLD_TRAITS.DEEP_OIL.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.DEEP_OIL.DESCRIPTION"
 msgid "Most of the <style=\"KKeyword\">Oil</style> in this world will need to be extracted with <link=\"OILWELLCAP\">Oil Well</link>s"
-msgstr "この小惑星の多くの<style=\"KKeyword\">原油</style>は、<link=\"OILWELLCAP\">油井</link>を使わないと抽出できません"
+msgstr "この小惑星にある<style=\"KKeyword\">原油</style>の大半は、<link=\"OILWELLCAP\">油井</link>を使わないと汲み上げることができません"
 
 #. STRINGS.WORLD_TRAITS.DEEP_OIL.NAME
 msgctxt "STRINGS.WORLD_TRAITS.DEEP_OIL.NAME"
@@ -75,7 +75,7 @@ msgstr "封じこめられた原油"
 #. STRINGS.WORLD_TRAITS.DISTRESS_SIGNAL.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.DISTRESS_SIGNAL.DESCRIPTION"
 msgid "This world contains a frozen friend from a long time ago"
-msgstr "この惑星には氷漬けになった古くからの友人がいます"
+msgstr "この小惑星には氷漬けになった古くからの友人がいます"
 
 #. STRINGS.WORLD_TRAITS.DISTRESS_SIGNAL.NAME
 msgctxt "STRINGS.WORLD_TRAITS.DISTRESS_SIGNAL.NAME"
@@ -85,17 +85,17 @@ msgstr "氷漬けの友人"
 #. STRINGS.WORLD_TRAITS.FROZEN_CORE.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.FROZEN_CORE.DESCRIPTION"
 msgid "This world has a chilly core of solid <link=\"ICE\">Ice</link>"
-msgstr "この小惑星には<link=\"ICE\">氷</link>の核があります"
+msgstr "この小惑星には冷たい<link=\"ICE\">氷</link>の中心核があります"
 
 #. STRINGS.WORLD_TRAITS.FROZEN_CORE.NAME
 msgctxt "STRINGS.WORLD_TRAITS.FROZEN_CORE.NAME"
 msgid "Frozen Core"
-msgstr "凍結核"
+msgstr "凍結した中心核"
 
 #. STRINGS.WORLD_TRAITS.GEOACTIVE.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.GEOACTIVE.DESCRIPTION"
 msgid "This world has more <style=\"KKeyword\">Geysers</style> and <style=\"KKeyword\">Vents</style> than usual"
-msgstr "この小惑星には通常より多めの<style=\"KKeyword\">間欠泉</style><style=\"KKeyword\">噴出孔</style>があります"
+msgstr "この小惑星には通常より多めの<style=\"KKeyword\">間欠泉</style>や<style=\"KKeyword\">噴出孔</style>があります"
 
 #. STRINGS.WORLD_TRAITS.GEOACTIVE.NAME
 msgctxt "STRINGS.WORLD_TRAITS.GEOACTIVE.NAME"
@@ -115,7 +115,7 @@ msgstr "ジオード"
 #. STRINGS.WORLD_TRAITS.GEODORMANT.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.GEODORMANT.DESCRIPTION"
 msgid "This world has fewer <style=\"KKeyword\">Geysers</style> and <style=\"KKeyword\">Vents</style> than usual"
-msgstr "この小惑星には通常より少なめの<style=\"KKeyword\">間欠泉</style><style=\"KKeyword\">噴出孔</style>があります"
+msgstr "この小惑星には通常より少なめの<style=\"KKeyword\">間欠泉</style>や<style=\"KKeyword\">噴出孔</style>しかありません"
 
 #. STRINGS.WORLD_TRAITS.GEODORMANT.NAME
 msgctxt "STRINGS.WORLD_TRAITS.GEODORMANT.NAME"
@@ -150,12 +150,12 @@ msgstr "この惑星の中心部は緑豊かな森林です"
 #. STRINGS.WORLD_TRAITS.LUSH_CORE.NAME
 msgctxt "STRINGS.WORLD_TRAITS.LUSH_CORE.NAME"
 msgid "Lush Core"
-msgstr "緑豊かなコア"
+msgstr "緑豊かな中心核"
 
 #. STRINGS.WORLD_TRAITS.MAGMA_VENTS.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.MAGMA_VENTS.DESCRIPTION"
 msgid "The <link=\"MAGMA\">Magma</link> from this world's core has leaked into the mantle and crust"
-msgstr "コアから流れ出した<link=\"MAGMA\">マグマ</link>が小惑星の隅々まで広がっています"
+msgstr "中心核の<link=\"MAGMA\">マグマ</link>が地殻やマントルなどの上層部に漏れ出しています"
 
 #. STRINGS.WORLD_TRAITS.MAGMA_VENTS.NAME
 msgctxt "STRINGS.WORLD_TRAITS.MAGMA_VENTS.NAME"
@@ -175,7 +175,7 @@ msgstr "金属の洞窟"
 #. STRINGS.WORLD_TRAITS.METAL_POOR.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.METAL_POOR.DESCRIPTION"
 msgid "There is a reduced amount of <style=\"KKeyword\">Metal Ore</style> on this world, proceed with caution!"
-msgstr "期待していたより<style=\"KKeyword\">金属鉱石</style>の産出が乏しいので、慎重に掘り進めましょう！"
+msgstr "期待していたより<style=\"KKeyword\">金属鉱石</style>の埋蔵量が乏しいので、計画は慎重に！"
 
 #. STRINGS.WORLD_TRAITS.METAL_POOR.NAME
 msgctxt "STRINGS.WORLD_TRAITS.METAL_POOR.NAME"
@@ -235,7 +235,7 @@ msgstr "放射性地殻"
 #. STRINGS.WORLD_TRAITS.SLIME_SPLATS.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.SLIME_SPLATS.DESCRIPTION"
 msgid "Sickly <link=\"SLIMEMOLD\">Slime</link> growths have crept all over this world"
-msgstr "この小惑星には気持ち悪い<link=\"SLIMEMOLD\">ヘドロ</link>塊が散りばめられています"
+msgstr "気持ち悪い<link=\"SLIMEMOLD\">ヘドロ</link>が増殖し、この小惑星の至るところに巣食っています"
 
 #. STRINGS.WORLD_TRAITS.SLIME_SPLATS.NAME
 msgctxt "STRINGS.WORLD_TRAITS.SLIME_SPLATS.NAME"

--- a/po/world_traits.po
+++ b/po/world_traits.po
@@ -95,7 +95,7 @@ msgstr "凍結した中心核"
 #. STRINGS.WORLD_TRAITS.GEOACTIVE.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.GEOACTIVE.DESCRIPTION"
 msgid "This world has more <style=\"KKeyword\">Geysers</style> and <style=\"KKeyword\">Vents</style> than usual"
-msgstr "この小惑星には通常より多めの<style=\"KKeyword\">間欠泉</style>や<style=\"KKeyword\">噴出孔</style>があります"
+msgstr "この小惑星の<style=\"KKeyword\">間欠泉</style>や<style=\"KKeyword\">噴出孔</style>は通常より多めです"
 
 #. STRINGS.WORLD_TRAITS.GEOACTIVE.NAME
 msgctxt "STRINGS.WORLD_TRAITS.GEOACTIVE.NAME"
@@ -115,7 +115,7 @@ msgstr "ジオード"
 #. STRINGS.WORLD_TRAITS.GEODORMANT.DESCRIPTION
 msgctxt "STRINGS.WORLD_TRAITS.GEODORMANT.DESCRIPTION"
 msgid "This world has fewer <style=\"KKeyword\">Geysers</style> and <style=\"KKeyword\">Vents</style> than usual"
-msgstr "この小惑星には通常より少なめの<style=\"KKeyword\">間欠泉</style>や<style=\"KKeyword\">噴出孔</style>しかありません"
+msgstr "この小惑星の<style=\"KKeyword\">間欠泉</style>や<style=\"KKeyword\">噴出孔</style>は通常より少なめです"
 
 #. STRINGS.WORLD_TRAITS.GEODORMANT.NAME
 msgctxt "STRINGS.WORLD_TRAITS.GEODORMANT.NAME"


### PR DESCRIPTION
小惑星の特性である `Frozen Core` と `Lush Core` の訳についてです。

どちらも小惑星の中心部（つまりゲームマップの最下部領域）を書き換える特性なので、`Core` の部分を共通化しました。名前から特性の影響範囲が伝わるよう`中心核` としています。

そのほか `world`(`小惑星`)の表記揺れや説明文の微修正をしています。
よろしくお願いします。