### PR TITLE
新規ゲームの設定に関する訳

### DIFF
--- a/po/ui.po
+++ b/po/ui.po
@@ -6343,56 +6343,63 @@ msgstr "オーディオ設定"
 #. STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.BLANK_DESC
 msgctxt "STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.BLANK_DESC"
 msgid "Select an asteroid style..."
-msgstr "小惑星のスタイルを選択"
+msgstr "小惑星のスタイルを選択してください..."
 
+# 表示幅に合わせて改行位置を調整
 #. STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.CLASSIC_DESC
 msgctxt "STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.CLASSIC_DESC"
 msgid ""
 "Scenarios similar to the <b>classic Oxygen Not Included</b> experience. Large starting asteroids with many resources.\n"
 "Less emphasis on space travel."
 msgstr ""
-"<b>クラシック Oxygen Not Included</b>に似せたシナリオです。様々な資源があり、スタート地点の小惑星は大きめです。\n"
-"\n"
-"宇宙旅行はあまり重視されません。"
+"従来の <b>Oxygen Not Included</b> に似たシナリオです。\n"
+"開始地点の小惑星は大きめで、多くの資源が眠っています。\n"
+"宇宙進出はあまり重視されません。"
 
 #. STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.CLASSIC_TITLE
 msgctxt "STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.CLASSIC_TITLE"
 msgid "Classic"
 msgstr "クラシック"
 
+# 表示幅に合わせて改行位置を調整
 #. STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.EVENT_DESC
 msgctxt "STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.EVENT_DESC"
 msgid "Alternative gameplay experiences, including experimental scenarios designed for special events."
-msgstr "通常とは異なるゲームプレイを体験。特別なイベント向けに設計された実験的なシナリオを含みます。"
+msgstr ""
+"通常とは一味違うゲームプレイを体験できます。\n"
+"特別なイベントのために設計された実験的なシナリオです。"
 
 #. STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.EVENT_TITLE
 msgctxt "STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.EVENT_TITLE"
 msgid "The Lab"
-msgstr "研究所"
+msgstr "実験室"
 
 #. STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.HEADER
 msgctxt "STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.HEADER"
 msgid "ASTEROID STYLE"
 msgstr "小惑星のスタイル"
 
+# 表示幅に合わせて改行位置を調整
 #. STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.SPACEDOUT_DESC
 msgctxt "STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.SPACEDOUT_DESC"
 msgid ""
 "Scenarios designed for the <b>Spaced Out! DLC</b>.\n"
 "Smaller starting asteroids with resources distributed across the starmap. More emphasis on space travel."
 msgstr ""
-"<b>Spaced Out ! DLC</b>向けのシナリオです。\n"
-"星図全体に資源が分散され、スタート地点の小惑星は小さくなります。宇宙旅行に重点を置いています。"
+"<b>Spaced Out ! DLC</b>のために設計されたシナリオです。\n"
+"開始地点の小惑星は小さめで、星図全体に資源が分散します。\n"
+"宇宙進出に重点を置いています。"
 
 #. STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.SPACEDOUT_TITLE
 msgctxt "STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.SPACEDOUT_TITLE"
 msgid "Spaced Out!"
 msgstr "Spaced Out!"
 
+# 未使用？
 #. STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.VANILLA_DESC
 msgctxt "STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.VANILLA_DESC"
 msgid "Scenarios designed for classic gameplay."
-msgstr "クラシックなゲームプレイに向けてデザインされたシナリオです。"
+msgstr "従来どおりのゲームプレイのために設計されたシナリオです。"
 
 #. STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.VANILLA_TITLE
 msgctxt "STRINGS.UI.FRONTEND.CLUSTERCATEGORYSELECTSCREEN.VANILLA_TITLE"
@@ -9135,27 +9142,34 @@ msgstr "有効化したコンテンツパック"
 #. STRINGS.UI.FRONTEND.MODESELECTSCREEN.BLANK_DESC
 msgctxt "STRINGS.UI.FRONTEND.MODESELECTSCREEN.BLANK_DESC"
 msgid "Select a playstyle..."
-msgstr "プレイスタイル選択..."
+msgstr "プレイスタイルを選択してください..."
 
 #. STRINGS.UI.FRONTEND.MODESELECTSCREEN.HEADER
 msgctxt "STRINGS.UI.FRONTEND.MODESELECTSCREEN.HEADER"
 msgid "GAME MODE"
 msgstr "ゲームモード"
 
+# 表示幅に合わせて改行位置を調整
 #. STRINGS.UI.FRONTEND.MODESELECTSCREEN.NOSWEAT_DESC
 msgctxt "STRINGS.UI.FRONTEND.MODESELECTSCREEN.NOSWEAT_DESC"
 msgid "When disaster strikes (and it inevitably will), take a deep breath and stay calm. You have ample time to find a solution."
-msgstr "もしも災害が襲ってきても（もちろん、必ず起こることですが）、深呼吸して落ち着いてください。解決策を見つけるための十分な時間があります。"
+msgstr ""
+"もし災害が襲ってきても（もちろん、必ず起こることですが）\n"
+"深呼吸して落ち着いてください。解決策を見つける時間は\n"
+"十分にあります。"
 
 #. STRINGS.UI.FRONTEND.MODESELECTSCREEN.NOSWEAT_TITLE
 msgctxt "STRINGS.UI.FRONTEND.MODESELECTSCREEN.NOSWEAT_TITLE"
 msgid "NO SWEAT"
 msgstr "楽勝"
 
+# 表示幅に合わせて改行位置を調整
 #. STRINGS.UI.FRONTEND.MODESELECTSCREEN.SURVIVAL_DESC
 msgctxt "STRINGS.UI.FRONTEND.MODESELECTSCREEN.SURVIVAL_DESC"
 msgid "Stay on your toes and one step ahead of this unforgiving world. One slip up could bring your colony crashing down."
-msgstr "慎重に、この容赦のない惑星へ一歩を踏み出してください。あなたのコロニーは、一度の誤りでも瓦解する可能性があります。"
+msgstr ""
+"慎重に、この過酷な小惑星へ一歩を踏み出してください。\n"
+"一度の誤りがコロニーを崩壊させてしまうこともあります。"
 
 #. STRINGS.UI.FRONTEND.MODESELECTSCREEN.SURVIVAL_TITLE
 msgctxt "STRINGS.UI.FRONTEND.MODESELECTSCREEN.SURVIVAL_TITLE"


### PR DESCRIPTION
新たなゲームを始める際に選択するゲームモードに関する訳を見直してみました。

日本語の禁則処理がないせいで見栄えがあまり良くない、複数行にわたる説明文の体裁を整えることに主眼を置いています。
`クラシック`モードと `Spaced Out!`モードの説明文は一行ごとに対応するようになっています。

![小惑星のスタイル](https://github.com/user-attachments/assets/3991a345-e934-4d3b-b538-2238517b57b2)
