### PR TITLE
Amenity（住環境設備）の訳

### DIFF
--- a/po/building.po
+++ b/po/building.po
@@ -81,7 +81,7 @@ msgstr "割り当て: 全員"
 #. STRINGS.BUILDING.STATUSITEMS.ASSIGNEDPUBLIC.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.ASSIGNEDPUBLIC.TOOLTIP"
 msgid "Any Duplicant can use this amenity"
-msgstr "複製人間全員がこのアメニティを使えます"
+msgstr "複製人間は誰でもこの設備を使えます"
 
 #. STRINGS.BUILDING.STATUSITEMS.ASSIGNEDTO.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.ASSIGNEDTO.NAME"
@@ -101,7 +101,7 @@ msgstr "割り当て: {0}"
 #. STRINGS.BUILDING.STATUSITEMS.ASSIGNEDTOROOM.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.ASSIGNEDTOROOM.TOOLTIP"
 msgid "Any Duplicant assigned to this <style=\"KKeyword\">Room</style> can use this amenity"
-msgstr "<style=\"KKeyword\">部屋</style>にいる割り当てられた複製人間がこのアメニティを使えます"
+msgstr "この<style=\"KKeyword\">部屋</style>に割り当てられた複製人間は誰でもこの設備を使えます"
 
 #. STRINGS.BUILDING.STATUSITEMS.AUTOPILOTACTIVE.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.AUTOPILOTACTIVE.NAME"

--- a/po/buildings.po
+++ b/po/buildings.po
@@ -4271,7 +4271,7 @@ msgstr "<link=\"FLOORLAMP\">ランプ</link>"
 #. STRINGS.BUILDINGS.PREFABS.FLOORSWITCH.DESC
 msgctxt "STRINGS.BUILDINGS.PREFABS.FLOORSWITCH.DESC"
 msgid "Weight plates can be used to turn on amenities only when Duplicants pass by."
-msgstr "加重プレートは複製人間通過時にアメニティを動かすために使えます。"
+msgstr "加重プレートを使えば、複製人間が通り過ぎた時だけ設備を動かすようにできます。"
 
 #. STRINGS.BUILDINGS.PREFABS.FLOORSWITCH.EFFECT
 msgctxt "STRINGS.BUILDINGS.PREFABS.FLOORSWITCH.EFFECT"

--- a/po/misc.po
+++ b/po/misc.po
@@ -782,8 +782,8 @@ msgid ""
 "Duplicants require better amenities over time.\n"
 "These Duplicants have increased their expectations:"
 msgstr ""
-"複製人間は時間経過とともにより良いアメニティを求めます。\n"
-"これらの複製人間は期待値が上昇しました:"
+"複製人間は時間が経つほど、より快適な生活環境を求めます。\n"
+"次の複製人間は期待値が上昇しました:"
 
 #. STRINGS.MISC.NOTIFICATIONS.INSUFFICIENTOXYGENLASTCYCLE.NAME
 msgctxt "STRINGS.MISC.NOTIFICATIONS.INSUFFICIENTOXYGENLASTCYCLE.NAME"

--- a/po/ui.po
+++ b/po/ui.po
@@ -195,7 +195,7 @@ msgstr "<link=\"BUILDCATEGORYFURNITURE\">家具</link>"
 #. STRINGS.UI.BUILDCATEGORIES.FURNITURE.TOOLTIP
 msgctxt "STRINGS.UI.BUILDCATEGORIES.FURNITURE.TOOLTIP"
 msgid "Amenities to keep my Duplicants happy, comfy and efficient. {Hotkey}"
-msgstr "複製人間が幸せで快適に効率よく生活するためのアメニティです。{Hotkey}"
+msgstr "複製人間が幸せで快適に効率よく生活するための家具や設備です。{Hotkey}"
 
 #. STRINGS.UI.BUILDCATEGORIES.HEP.NAME
 msgctxt "STRINGS.UI.BUILDCATEGORIES.HEP.NAME"
@@ -887,7 +887,7 @@ msgstr "灌漑<style=\"KKeyword\">パイプ</style>が接続できるように�
 #. STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.ASSIGNEDDUPLICANT
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.ASSIGNEDDUPLICANT"
 msgid "This amenity may only be used by the Duplicant it is assigned to"
-msgstr "このアメニティは割り当てられた複製人間だけが使用できます"
+msgstr "この設備は割り当てられた複製人間だけが使用できます"
 
 #. STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.BATTERYCAPACITY
 msgctxt "STRINGS.UI.BUILDINGEFFECTS.TOOLTIPS.BATTERYCAPACITY"
@@ -4881,10 +4881,13 @@ msgctxt "STRINGS.UI.DETAILTABS.PERSONALITY.EQUIPMENT.GROUPNAME_OWNABLE"
 msgid "EQUIPMENT"
 msgstr "装備"
 
+# 複製人間の「個性」タブに表示される欄の名称
+# ここには個人に割り当てた（ベッドやトイレ、食卓などの）設備が一覧表示される
+# 公共設定の（誰でも使える）設備は表示されない
 #. STRINGS.UI.DETAILTABS.PERSONALITY.EQUIPMENT.GROUPNAME_ROOMS
 msgctxt "STRINGS.UI.DETAILTABS.PERSONALITY.EQUIPMENT.GROUPNAME_ROOMS"
 msgid "AMENITIES"
-msgstr "アメニティ"
+msgstr "住環境"
 
 #. STRINGS.UI.DETAILTABS.PERSONALITY.EQUIPMENT.NO_ASSIGNABLES
 msgctxt "STRINGS.UI.DETAILTABS.PERSONALITY.EQUIPMENT.NO_ASSIGNABLES"
@@ -5004,7 +5007,7 @@ msgid ""
 "View this Duplicant's personality, skills, traits and amenities"
 msgstr ""
 "<b>人物紹介</b>\n"
-"この複製人間の個性、スキル、特性、アメニティを参照します"
+"この複製人間の個性、スキル、特性、住環境を参照します"
 
 #. STRINGS.UI.DETAILTABS.PROCESS_CONDITIONS.ALL
 msgctxt "STRINGS.UI.DETAILTABS.PROCESS_CONDITIONS.ALL"
@@ -12939,7 +12942,7 @@ msgstr "家具"
 #. STRINGS.UI.NEWBUILDCATEGORIES.FURNITURE.TOOLTIP
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.FURNITURE.TOOLTIP"
 msgid "Amenities to keep my Duplicants happy, comfy and efficient. {Hotkey}"
-msgstr "複製人間が幸せで快適に効率よく生活するためのアメニティです。{Hotkey}"
+msgstr "複製人間が幸せで快適に効率よく生活するための家具や設備です。{Hotkey}"
 
 #. STRINGS.UI.NEWBUILDCATEGORIES.GENERATORS.BUILDMENUTITLE
 msgctxt "STRINGS.UI.NEWBUILDCATEGORIES.GENERATORS.BUILDMENUTITLE"
@@ -25973,7 +25976,7 @@ msgstr "{0}"
 #. STRINGS.UI.UISIDESCREENS.OWNABLESSIDESCREEN.CATEGORIES.AMENITIES
 msgctxt "STRINGS.UI.UISIDESCREENS.OWNABLESSIDESCREEN.CATEGORIES.AMENITIES"
 msgid "Amenities"
-msgstr "アメニティ"
+msgstr "住環境"
 
 #. STRINGS.UI.UISIDESCREENS.OWNABLESSIDESCREEN.CATEGORIES.SUITS
 msgctxt "STRINGS.UI.UISIDESCREENS.OWNABLESSIDESCREEN.CATEGORIES.SUITS"
@@ -25998,7 +26001,7 @@ msgstr "該当なし"
 #. STRINGS.UI.UISIDESCREENS.OWNABLESSIDESCREEN.TITLE
 msgctxt "STRINGS.UI.UISIDESCREENS.OWNABLESSIDESCREEN.TITLE"
 msgid "Equipment and Amenities"
-msgstr "装備とアメニティ"
+msgstr "装備と住環境"
 
 #. STRINGS.UI.UISIDESCREENS.OWNABLESSIDESCREEN.TOOLTIPS.ITEM_ASSIGNED
 msgctxt "STRINGS.UI.UISIDESCREENS.OWNABLESSIDESCREEN.TOOLTIPS.ITEM_ASSIGNED"


### PR DESCRIPTION
`Amenity` の訳についてです。
このゲームにおいては、ベッドやトイレ、食卓など、複製人間の住環境にかかわる設備全般のことです。

既存の訳では`アメニティ`と片仮名になっていますが、多義的な言葉なので、場面に応じて訳しました。
（`アメニティ`というと、ホテルの部屋に備え付けのタオルや歯ブラシといった消耗品が真っ先に思い浮かびます）

- 具体的な個別の設備を指す場合は、単に`設備`
- ひとりの複製人間が占有している設備全体を指す場合は`住環境`

などです。
よろしくお願いします。