### PR TITLE
植物と収穫物の区別

### DIFF
--- a/po/creatures.po
+++ b/po/creatures.po
@@ -1120,7 +1120,7 @@ msgstr "ハネナンキンは甘くて栄養豊富な根菜で、<link=\"FOOD\">
 #. STRINGS.CREATURES.SPECIES.CARROTPLANT.DOMESTICATEDDESC
 msgctxt "STRINGS.CREATURES.SPECIES.CARROTPLANT.DOMESTICATEDDESC"
 msgid "This plant produces edible <link=\"CARROT\">Plume Squash</link>."
-msgstr "この植物は食用<link=\"CARROT\">ハネナンキン</link>を生産します。"
+msgstr "この植物からは食用の<link=\"CARROT\">ハネナンキンの実</link>を収穫できます。"
 
 #. STRINGS.CREATURES.SPECIES.CARROTPLANT.NAME
 msgctxt "STRINGS.CREATURES.SPECIES.CARROTPLANT.NAME"
@@ -2031,7 +2031,7 @@ msgid ""
 "\n"
 "Their thick overcoats can be shorn for <link=\"BASICFABRIC\">Reed Fiber</link>."
 msgstr ""
-"バンモスは<link=\"CARROT\">ハネナンキン</link>や<link=\"BEANPLANTSEED\">ノッシュ豆</link>、<link=\"FRIESCARROT\">ナンキンフライ</link>を食べて生きる、動きの鈍い非敵対的な生き物です。\n"
+"バンモスは<link=\"CARROT\">ハネナンキンの実</link>や<link=\"BEANPLANTSEED\">ノッシュ豆</link>、<link=\"FRIESCARROT\">ナンキンフライ</link>を食べて生きる、動きの鈍い非敵対的な生き物です。\n"
 "\n"
 "厚い外套を刈ると<link=\"BASICFABRIC\">リード繊維</link>が手に入ります。"
 
@@ -2068,7 +2068,7 @@ msgid ""
 "\n"
 "Their ornate crests grow only when they are fed <link=\"FRIESCARROT\">Squash Fries</link>."
 msgstr ""
-"オウサマバンモスは<link=\"CARROT\">ハネナンキン</link>や<link=\"BEANPLANTSEED\">ノッシュ豆</link>、<link=\"FRIESCARROT\">ナンキンフライ</link>を食べて生きる、動きの鈍い非敵対的な生き物です。\n"
+"オウサマバンモスは<link=\"CARROT\">ハネナンキンの実</link>や<link=\"BEANPLANTSEED\">ノッシュ豆</link>、<link=\"FRIESCARROT\">ナンキンフライ</link>を食べて生きる、動きの鈍い非敵対的な生き物です。\n"
 "\n"
 "彼らの華やかな冠は<link=\"FRIESCARROT\">ナンキンフライ</link>を与えた時のみ成長します。"
 

--- a/po/creatures.po
+++ b/po/creatures.po
@@ -1117,6 +1117,7 @@ msgctxt "STRINGS.CREATURES.SPECIES.CARROTPLANT.DESC"
 msgid "Plume Squashes are sweet, nutrient-rich tubers that can be harvested for <link=\"FOOD\">Food</link>."
 msgstr "ハネナンキンは甘くて栄養豊富な根菜で、<link=\"FOOD\">食糧</link>として収穫できます。"
 
+# 収穫前のハネナンキン(Plume Squash Plant)と区別するため「の実」を付け足す
 #. STRINGS.CREATURES.SPECIES.CARROTPLANT.DOMESTICATEDDESC
 msgctxt "STRINGS.CREATURES.SPECIES.CARROTPLANT.DOMESTICATEDDESC"
 msgid "This plant produces edible <link=\"CARROT\">Plume Squash</link>."
@@ -2024,6 +2025,7 @@ msgctxt "STRINGS.CREATURES.SPECIES.ICEBELLY.BABY.NAME"
 msgid "<link=\"ICEBELLY\">Bammini</link>"
 msgstr "<link=\"ICEBELLY\">バンモス幼体</link>"
 
+# 収穫前のハネナンキン(Plume Squash Plant)と区別するため「の実」を付け足す
 #. STRINGS.CREATURES.SPECIES.ICEBELLY.DESC
 msgctxt "STRINGS.CREATURES.SPECIES.ICEBELLY.DESC"
 msgid ""
@@ -2061,6 +2063,7 @@ msgctxt "STRINGS.CREATURES.SPECIES.ICEBELLY.VARIANT_GOLD.BABY.NAME"
 msgid "<link=\"GOLDBELLY\">Regal Bammini</link>"
 msgstr "<link=\"GOLDBELLY\">オウサマバンモス幼体</link>"
 
+# 収穫前のハネナンキン(Plume Squash Plant)と区別するため「の実」を付け足す
 #. STRINGS.CREATURES.SPECIES.ICEBELLY.VARIANT_GOLD.DESC
 msgctxt "STRINGS.CREATURES.SPECIES.ICEBELLY.VARIANT_GOLD.DESC"
 msgid ""

--- a/po/items.po
+++ b/po/items.po
@@ -363,7 +363,7 @@ msgstr "大地の恵みが感じられる上品な食用の根菜です。"
 #. STRINGS.ITEMS.FOOD.CARROT.NAME
 msgctxt "STRINGS.ITEMS.FOOD.CARROT.NAME"
 msgid "<link=\"CARROT\">Plume Squash</link>"
-msgstr "<link=\"CARROT\">ハネナンキン</link>"
+msgstr "<link=\"CARROT\">ハネナンキンの実</link>"
 
 #. STRINGS.ITEMS.FOOD.COLDWHEATBREAD.DESC
 msgctxt "STRINGS.ITEMS.FOOD.COLDWHEATBREAD.DESC"
@@ -714,7 +714,7 @@ msgstr "<link=\"FRIESCARROT\">ナンキンフライ</link>"
 #. STRINGS.ITEMS.FOOD.FRIESCARROT.RECIPEDESC
 msgctxt "STRINGS.ITEMS.FOOD.FRIESCARROT.RECIPEDESC"
 msgid "Crunchy sticks of <link=\"CARROT\">Plume Squash</link> deep-fried in <link=\"TALLOW\">Tallow</link>."
-msgstr "<link=\"CARROT\">ハネナンキン</link>を<link=\"TALLOW\">獣脂</link>で揚げたものです。"
+msgstr "<link=\"CARROT\">ハネナンキンの実</link>を<link=\"TALLOW\">獣脂</link>で揚げたものです。"
 
 #. STRINGS.ITEMS.FOOD.FRUITCAKE.DESC
 msgctxt "STRINGS.ITEMS.FOOD.FRUITCAKE.DESC"
@@ -818,7 +818,7 @@ msgstr ""
 #. STRINGS.ITEMS.FOOD.ICECAVESFORAGEPLANT.NAME
 msgctxt "STRINGS.ITEMS.FOOD.ICECAVESFORAGEPLANT.NAME"
 msgid "<link=\"ICECAVESFORAGEPLANT\">Sherberry</link>"
-msgstr "<link=\"ICECAVESFORAGEPLANT\">シャーベリー</link>"
+msgstr "<link=\"ICECAVESFORAGEPLANT\">シャーベリーの果実</link>"
 
 #. STRINGS.ITEMS.FOOD.LETTUCE.DESC
 msgctxt "STRINGS.ITEMS.FOOD.LETTUCE.DESC"
@@ -1604,7 +1604,7 @@ msgid ""
 "\n"
 "Duplicants can produce new <link=\"ELECTROBANK\">Squash Power Banks</link> at the <link=\"CRAFTINGTABLE\">Crafting Station</link>."
 msgstr ""
-"<link=\"CARROT\">ハネナンキン</link>から作られた、使い捨ての有機<link=\"ELECTROBANK\">パワーバンク</link>です。\n"
+"<link=\"CARROT\">ハネナンキンの実</link>から作られた、使い捨ての有機<link=\"ELECTROBANK\">パワーバンク</link>です。\n"
 "\n"
 "<link=\"LARGEELECTROBANKDISCHARGER\">ソケット端末</link>または<link=\"SMALLELECTROBANKDISCHARGER\">壁ソケット</link>経由で設備に給電できます。\n"
 "\n"

--- a/po/items.po
+++ b/po/items.po
@@ -360,6 +360,7 @@ msgctxt "STRINGS.ITEMS.FOOD.CARROT.DESC"
 msgid "An edible tuber with an earthy, elegant flavor."
 msgstr "大地の恵みが感じられる上品な食用の根菜です。"
 
+# 収穫前のハネナンキン(Plume Squash Plant)と区別するため「の実」を付け足す
 #. STRINGS.ITEMS.FOOD.CARROT.NAME
 msgctxt "STRINGS.ITEMS.FOOD.CARROT.NAME"
 msgid "<link=\"CARROT\">Plume Squash</link>"
@@ -711,6 +712,7 @@ msgctxt "STRINGS.ITEMS.FOOD.FRIESCARROT.NAME"
 msgid "<link=\"FRIESCARROT\">Squash Fries</link>"
 msgstr "<link=\"FRIESCARROT\">ナンキンフライ</link>"
 
+# 収穫前のハネナンキン(Plume Squash Plant)と区別するため「の実」を付け足す
 #. STRINGS.ITEMS.FOOD.FRIESCARROT.RECIPEDESC
 msgctxt "STRINGS.ITEMS.FOOD.FRIESCARROT.RECIPEDESC"
 msgid "Crunchy sticks of <link=\"CARROT\">Plume Squash</link> deep-fried in <link=\"TALLOW\">Tallow</link>."
@@ -815,6 +817,7 @@ msgstr ""
 "\n"
 "植えなおすことはできません。"
 
+# 収穫前のシャーベリー(Sherberry Plant)と区別するため「の果実」を付け足す
 #. STRINGS.ITEMS.FOOD.ICECAVESFORAGEPLANT.NAME
 msgctxt "STRINGS.ITEMS.FOOD.ICECAVESFORAGEPLANT.NAME"
 msgid "<link=\"ICECAVESFORAGEPLANT\">Sherberry</link>"
@@ -1595,6 +1598,7 @@ msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK.NAME"
 msgid "<link=\"ELECTROBANK\">Eco Power Bank</link>"
 msgstr "<link=\"ELECTROBANK\">エコ パワーバンク</link>"
 
+# 収穫前のハネナンキン(Plume Squash Plant)と区別するため「の実」を付け足す
 #. STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_CARROT.DESC
 msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_CARROT.DESC"
 msgid ""


### PR DESCRIPTION
収穫前の植物名と、収穫後の食品名が同一で区別できないものがあったため、区別できるようにしてみました。
|原語|案|
|-|-|
|Plume Squash Plant|ハネナンキン|
|Plume Squash|ハネナンキンの実|
|Sherberry Plant|シャーベリー|
|Sherberry|シャーベリーの果実|

既存の訳には `hoge Plant` を `hogeの木`としているものがありますが、`ハネナンキン`は根菜(tuber)という説明があり、見た目も樹木ではないので、このようにしています。