### PR TITLE
溶融したガラス -> 融解ガラス

### DIFF
--- a/po/elements.po
+++ b/po/elements.po
@@ -1461,6 +1461,7 @@ msgctxt "STRINGS.ELEMENTS.MOLTENGLASS.DESC"
 msgid "Molten Glass is a composite of granular rock, heated into a <link=\"ELEMENTSLIQUID\">Liquid</link> state."
 msgstr "融解ガラスは、<link=\"ELEMENTSLIQUID\">液体</link>になるまで熱せられた火成岩の混合物です。"
 
+# 溶融したガラス、ではない理由は #427 参照
 #. STRINGS.ELEMENTS.MOLTENGLASS.NAME
 msgctxt "STRINGS.ELEMENTS.MOLTENGLASS.NAME"
 msgid "<link=\"MOLTENGLASS\">Molten Glass</link>"

--- a/po/elements.po
+++ b/po/elements.po
@@ -1464,7 +1464,7 @@ msgstr "融解ガラスは、<link=\"ELEMENTSLIQUID\">液体</link>になるま�
 #. STRINGS.ELEMENTS.MOLTENGLASS.NAME
 msgctxt "STRINGS.ELEMENTS.MOLTENGLASS.NAME"
 msgid "<link=\"MOLTENGLASS\">Molten Glass</link>"
-msgstr "<link=\"MOLTENGLASS\">溶融したガラス</link>"
+msgstr "<link=\"MOLTENGLASS\">融解ガラス</link>"
 
 #. STRINGS.ELEMENTS.MOLTENGOLD.DESC
 msgctxt "STRINGS.ELEMENTS.MOLTENGOLD.DESC"


### PR DESCRIPTION
Molten Grassの表現に `融解ガラス` と `溶融したガラス` が混在しているのに気づいたので、一つに統一したく考えています。

液体金属系は `溶融した銅` のように溶融したで統一されているのですが、ガラスに関してはインターネット上の既存の攻略文書などを見ていると `融解ガラス` の方が一般で普及しているので、おそらく長らくそちらが使われていたと推測します。それならと本pull requestでは融解ガラス側に統一させてみました。 (`git grep 溶融したガラス` で0件ヒットする状態になっていることを確認済みです)

逆に、 溶融したガラス側に統一するならば、そのときはそのように本pull requestを変更します!