### PR TITLE
Grilling Boosterの訳について

### DIFF
--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -14390,12 +14390,12 @@ msgstr "バイオニック複製人間に、店を開けるほど美味しい料
 #. STRINGS.DUPLICANTS.TRAITS.STARTWITHBOOSTER_COOK1.NAME
 msgctxt "STRINGS.DUPLICANTS.TRAITS.STARTWITHBOOSTER_COOK1.NAME"
 msgid "<link=\"BOOSTERCOOK1\">Grilling Booster</link>"
-msgstr "<link=\"BOOSTERCOOK1\">グリルブースター</link>"
+msgstr "<link=\"BOOSTERCOOK1\">グリル調理ブースター</link>"
 
 #. STRINGS.DUPLICANTS.TRAITS.STARTWITHBOOSTER_COOK1.SHORT_DESC
 msgctxt "STRINGS.DUPLICANTS.TRAITS.STARTWITHBOOSTER_COOK1.SHORT_DESC"
 msgid "Starts with a preinstalled <b><link=\"BOOSTERCOOK1\">Grilling Booster</link></b>"
-msgstr "<b><link=\"BOOSTERCOOK1\">グリルブースター</link></b>を装着して開始"
+msgstr "<b><link=\"BOOSTERCOOK1\">グリル調理ブースター</link></b>を装着して開始"
 
 #. STRINGS.DUPLICANTS.TRAITS.STARTWITHBOOSTER_COOK1.SHORT_DESC_TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.TRAITS.STARTWITHBOOSTER_COOK1.SHORT_DESC_TOOLTIP"

--- a/po/items.po
+++ b/po/items.po
@@ -50,7 +50,7 @@ msgstr "バイオニック複製人間に美味しいプロの調理スキルを
 #. STRINGS.ITEMS.BIONIC_BOOSTERS.BOOSTER_COOK1.NAME
 msgctxt "STRINGS.ITEMS.BIONIC_BOOSTERS.BOOSTER_COOK1.NAME"
 msgid "<link=\"BOOSTERCOOK1\">Grilling Booster</link>"
-msgstr "<link=\"BOOSTERCOOK1\">グリルブースター</link>"
+msgstr "<link=\"BOOSTERCOOK1\">グリル調理ブースター</link>"
 
 #. STRINGS.ITEMS.BIONIC_BOOSTERS.BOOSTER_DIG1.DESC
 msgctxt "STRINGS.ITEMS.BIONIC_BOOSTERS.BOOSTER_DIG1.DESC"


### PR DESCRIPTION
`Grilling Booster` の名称が`グリルブースター`になっていますが、

スキル名のほうは
- `Grilling` → `グリル調理 I`
- `Grilling II` → `グリル調理 II`

となっています。
ほかのブースター名と同じくスキル名に合わせるのであれば`グリル調理ブースター`になると思います。

意図的に崩しているのか単なる見落としか分からなかったため、念のため修正案をリクエストします。
よろしくお願いします。