### PR TITLE
電力バンクの表記揺れについて

### DIFF
--- a/po/building.po
+++ b/po/building.po
@@ -3583,6 +3583,7 @@ msgctxt "STRINGS.BUILDING.STATUSITEMS.POWERBANKCHARGERINPROGRESS.NAME"
 msgid "Recharging Power Bank: {0}"
 msgstr "電力バンク充電中: {0}"
 
+# {0}はワット数
 #. STRINGS.BUILDING.STATUSITEMS.POWERBANKCHARGERINPROGRESS.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.POWERBANKCHARGERINPROGRESS.TOOLTIP"
 msgid ""
@@ -3590,7 +3591,7 @@ msgid ""
 "\n"
 "The <style=\"KKeyword\">Power Bank</style> will be dropped once charging is complete"
 msgstr ""
-"この設備は<style=\"KKeyword\">電力バンク</style>を{0} 充電中です\n"
+"この設備は<style=\"KKeyword\">電力バンク</style>を {0} で充電中です\n"
 "\n"
 "<style=\"KKeyword\">電力バンク</style>は充電が完了すると地面に落下します"
 

--- a/po/buildings.po
+++ b/po/buildings.po
@@ -3009,7 +3009,7 @@ msgstr "バイオニック複製人間の活動は安定した電力供給に依
 #. STRINGS.BUILDINGS.PREFABS.ELECTROBANKCHARGER.EFFECT
 msgctxt "STRINGS.BUILDINGS.PREFABS.ELECTROBANKCHARGER.EFFECT"
 msgid "Converts empty <link=\"ELECTROBANK\">Eco Power Banks</link> into fully charged units ready for reuse."
-msgstr "空の<link=\"ELECTROBANK\">エコ電力バンク</link>を再利用できるフル充電済みのユニットに変換します。"
+msgstr "空の<link=\"ELECTROBANK\">エコ 電力バンク</link>を完全に充電し、再利用できるようにします。"
 
 #. STRINGS.BUILDINGS.PREFABS.ELECTROBANKCHARGER.NAME
 msgctxt "STRINGS.BUILDINGS.PREFABS.ELECTROBANKCHARGER.NAME"
@@ -11410,7 +11410,7 @@ msgstr "<link=\"OXYGENMASKSTATION\">酸素マスク端末</link>"
 #. STRINGS.BUILDINGS.PREFABS.OXYLITEREFINERY.DESC
 msgctxt "STRINGS.BUILDINGS.PREFABS.OXYLITEREFINERY.DESC"
 msgid "Oxylite is a solid and easily transportable source of consumable oxygen."
-msgstr "オキシライトは固体で持ち運び可能な酸素資源です。"
+msgstr "オキシライトは固体であり、持ち運びが容易な酸素の発生源です。"
 
 #. STRINGS.BUILDINGS.PREFABS.OXYLITEREFINERY.EFFECT
 msgctxt "STRINGS.BUILDINGS.PREFABS.OXYLITEREFINERY.EFFECT"
@@ -15235,7 +15235,7 @@ msgstr "<link=\"SUPERMATERIALREFINERY\">分子合成機</link>"
 #. STRINGS.BUILDINGS.PREFABS.SUPERMATERIALREFINERY.SELF_CHARGING_POWERBANK_RECIPE_DESCRIPTION
 msgctxt "STRINGS.BUILDINGS.PREFABS.SUPERMATERIALREFINERY.SELF_CHARGING_POWERBANK_RECIPE_DESCRIPTION"
 msgid "Atomic Power Banks are portable, self-charging units used for isolated <link=\"POWER\">Power</link> grids."
-msgstr "スイッチは<link=\"POWER\">配電</link>設備に接続されている必要があります。"
+msgstr "原子力 電力バンクは持ち運び可能な、自分自身を充電できる電力ユニットです。隔離された<link=\"POWER\">電力</link>網で使用されます。"
 
 #. STRINGS.BUILDINGS.PREFABS.SUPERMATERIALREFINERY.SUPERCOOLANT_RECIPE_DESCRIPTION
 msgctxt "STRINGS.BUILDINGS.PREFABS.SUPERMATERIALREFINERY.SUPERCOOLANT_RECIPE_DESCRIPTION"

--- a/po/codex.po
+++ b/po/codex.po
@@ -5216,7 +5216,7 @@ msgid ""
 "\n"
 "They are not foldable."
 msgstr ""
-"データバンクはポータブルストレージメディアの一種です。不揮発性、堅牢性、実用的な研究用途で高く評価されています。\n"
+"データバンクは持ち運びできる記憶媒体の一種です。不揮発性で堅牢性に優れ、研究の現場で重宝されています。\n"
 "\n"
 "折り畳み式ではありません。"
 
@@ -5459,17 +5459,17 @@ msgid ""
 "\n"
 "Cautious handling is required, as liquid exposure (or expiration, for self-charging power banks) can lead to explosions."
 msgstr ""
-"電力バンクは持ち運べる<link=\"POWER\">電力</link>格納容器で、移動体や隔離されたエリアに電力を供給できます。\n"
+"電力バンクは持ち運びできる<link=\"POWER\">電力</link>貯蔵容器で、移動体や隔離された区域に電力を供給するために使われます。\n"
 "\n"
-"使い捨ての電力バンクは製造が簡単ですが、長期的には充電式またはセルフ充電式のモデルの方が効率的です。\n"
+"使い捨ての電力バンクは製作が簡単ですが、長期的には充電式または自己充電式のモデルの方が効率的です。\n"
 "\n"
-"液体への曝露(セルフ充電式の電力バンクの場合は有効期限切れ)は爆発につながる可能性があるため、慎重な取り扱いが必要です。"
+"液体に接触すると(自己充電式の電力バンクの場合は寿命を迎えたりしても)爆発につながる危険があるため、取り扱いには注意が必要です。"
 
 # 格納庫以外にも、農地タイルでこのアクションが使用できた
 #. STRINGS.CODEX.ELECTROBANK.SUBTITLE
 msgctxt "STRINGS.CODEX.ELECTROBANK.SUBTITLE"
 msgid "Portable Storage"
-msgstr "ポータブルストレージ"
+msgstr "持ち運びできる貯蔵装置"
 
 #. STRINGS.CODEX.ELECTROBANK.TITLE
 msgctxt "STRINGS.CODEX.ELECTROBANK.TITLE"
@@ -9304,7 +9304,7 @@ msgid ""
 "Electrical power is required to run many of the buildings in a base. Different buildings requires different amounts of power to run. Power can be transferred to buildings that require it using <link=\"WIRE\">Wires</link>.\n"
 "\n"
 msgstr ""
-"電力は基地内の設備を稼働させるために必要です。設備ごとに稼働させるための電力が異なります。電力は<link=\"WIRE\">電線</link>によって供給されます。\n"
+"コロニー内にある多くの設備は稼働するために電力を必要とします。設備によって必要とする電力の量も異なります。電力は<link=\"WIRE\">電線</link>によって送電されます。\n"
 "\n"
 
 #. STRINGS.CODEX.POWER.PARAGRAPH_2
@@ -9315,9 +9315,9 @@ msgid ""
 "Power can also be stored in portable <link=\"ELECTROBANK\">Power Banks</link>.\n"
 "\n"
 msgstr ""
-"設備の中には発電するものがあります。複製人間は<link=\"MANUALGENERATOR\">人力発電機</link>で発電することができます。電力が生成されると、設備によって消費されるか<link=\"BATTERY\">バッテリー</link>に蓄えられます。消費されない、または蓄えられない電力は捨てられます。バッテリーと発電機は稼働中に発<link=\"HEAT\">熱</link>する傾向にあります。\n"
+"設備の中には発電できるものがあります。複製人間は<link=\"MANUALGENERATOR\">人力発電機</link>を使って走ることで汚染のない電力を生み出すことができます。生み出された電力は設備を稼働させるために消費され、余剰分は<link=\"BATTERY\">バッテリー</link>に蓄えられます。消費されず、蓄電もされない電力は捨てられます。バッテリーと発電機は稼働中にかなりの<link=\"HEAT\">熱</link>を発する傾向にあります。\n"
 "\n"
-"電力はポータブル<link=\"ELECTROBANK\">電力バンク</link>に蓄電することもできます。\n"
+"電力は持ち運びできる<link=\"ELECTROBANK\">電力バンク</link>に蓄電することもできます。\n"
 "\n"
 
 #. STRINGS.CODEX.POWER.PARAGRAPH_3

--- a/po/duplicants.po
+++ b/po/duplicants.po
@@ -3693,7 +3693,7 @@ msgstr "空の電力バンクを排出中"
 #. STRINGS.DUPLICANTS.CHORES.UNLOADELECTROBANK.TOOLTIP
 msgctxt "STRINGS.DUPLICANTS.CHORES.UNLOADELECTROBANK.TOOLTIP"
 msgid "Bionic Duplicants automatically offload depleted <style=\"KKeyword\">Power Banks</style>"
-msgstr "バイオニック複製人間は使用済みの<style=\"KKeyword\">電力バンク</style>を自動的に排出します"
+msgstr "バイオニック複製人間は残量が尽きた<style=\"KKeyword\">電力バンク</style>を自動的に排出します"
 
 #. STRINGS.DUPLICANTS.CHORES.UPROOT.NAME
 msgctxt "STRINGS.DUPLICANTS.CHORES.UPROOT.NAME"

--- a/po/items.po
+++ b/po/items.po
@@ -1633,6 +1633,12 @@ msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.EGG_SHELL.NAME"
 msgid "<link=\"EGGSHELL\">Egg Shell</link>"
 msgstr "<link=\"EGGSHELL\">卵の殻</link>"
 
+# エコ 電力バンクのリンク先は"ELECTROBANK"
+# 水に濡れると破損する。H2O以外の液体は基本的に平気。
+# ・水、汚染水、塩水、濃塩水: 壊れる
+# ・石油、エタノール、液体残滓: 影響なし
+# ・モー乳: 影響なし
+# ・蒸気: 影響なし
 #. STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK.DESC
 msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK.DESC"
 msgid ""
@@ -1648,9 +1654,9 @@ msgstr ""
 "\n"
 "<link=\"LARGEELECTROBANKDISCHARGER\">大型放電器</link>または<link=\"SMALLELECTROBANKDISCHARGER\">コンパクト放電器</link>経由で設備に給電できます。\n"
 "\n"
-"複製人間は<link=\"ADVANCEDCRAFTINGTABLE\">はんだ付け端末</link>で新しい<link=\"ELECTROBANK\">エコ 電力バンク</link>を生産できます。\n"
+"複製人間は<link=\"ADVANCEDCRAFTINGTABLE\">はんだ付け端末</link>で新しい<link=\"ELECTROBANK\">エコ 電力バンク</link>を製作できます。\n"
 "\n"
-"湿気が天敵です。"
+"水には濡らさないでください。"
 
 #. STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK.NAME
 msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK.NAME"
@@ -1664,14 +1670,15 @@ msgid ""
 "\n"
 "It must be recharged at a <link=\"ELECTROBANKCHARGER\">Power Bank Charger</link> before it can be reused."
 msgstr ""
-"残量ゼロの<link=\"ELECTROBANK\">電力バンク</link>です。\n"
+"残量が尽きた<link=\"ELECTROBANK\">電力バンク</link>です。\n"
 "\n"
 "再利用するには<link=\"ELECTROBANKCHARGER\">電力バンク充電器</link>で充電する必要があります。"
 
+# 空のエコ 電力バンクのリンク先は本来なら"ELECTROBANKEMPTY"だが、今は存在しない
 #. STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_EMPTY.NAME
 msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_EMPTY.NAME"
 msgid "<link=\"ELECTROBANK\">Empty Eco Power Bank</link>"
-msgstr "<link=\"ELECTROBANK\">空のエコ電力バンク</link>"
+msgstr "<link=\"ELECTROBANK\">空のエコ 電力バンク</link>"
 
 #. STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_GARBAGE.DESC
 msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_GARBAGE.DESC"
@@ -1680,15 +1687,16 @@ msgid ""
 "\n"
 "It can be salvaged for <link=\"KATAIRITE\">Abyssalite</link> at the <link=\"ROCKCRUSHER\">Rock Crusher</link>."
 msgstr ""
-"使用回数上限に達した<link=\"ELECTROBANK\">電力バンク</link>です。\n"
+"寿命を迎えた<link=\"ELECTROBANK\">電力バンク</link>です。\n"
 "\n"
 "<link=\"ROCKCRUSHER\">岩石粉砕機</link>で<link=\"KATAIRITE\">アビサライト</link>に分解できます。"
 
 #. STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_GARBAGE.NAME
 msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_GARBAGE.NAME"
 msgid "<link=\"ELECTROBANK\">Power Bank Scrap</link>"
-msgstr "<link=\"ELECTROBANK\">廃品電力バンク</link>"
+msgstr "<link=\"ELECTROBANK\">電力バンクの廃品</link>"
 
+# メタル 電力バンクのリンク先は"ELECTROBANKMETALORE"
 #. STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_METAL_ORE.DESC
 msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_METAL_ORE.DESC"
 msgid ""
@@ -1704,15 +1712,16 @@ msgstr ""
 "\n"
 "<link=\"LARGEELECTROBANKDISCHARGER\">大型放電器</link>または<link=\"SMALLELECTROBANKDISCHARGER\">コンパクト放電器</link>経由で設備に給電できます。\n"
 "\n"
-"複製人間は<link=\"CRAFTINGTABLE\">工作端末</link>で新しい<link=\"ELECTROBANK\">メタル 電力バンク</link>を生産できます。\n"
+"複製人間は<link=\"CRAFTINGTABLE\">工作端末</link>で新しい<link=\"ELECTROBANKMETALORE\">メタル 電力バンク</link>を製作できます。\n"
 "\n"
-"湿気が天敵です。"
+"水には濡らさないでください。"
 
 #. STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_METAL_ORE.NAME
 msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_METAL_ORE.NAME"
 msgid "<link=\"ELECTROBANKMETALORE\">Metal Power Bank</link>"
 msgstr "<link=\"ELECTROBANKMETALORE\">メタル 電力バンク</link>"
 
+# 説明にはないが、ほかの電力バンクと同様に、水に濡れると破損する。
 #. STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_SELFCHARGING.DESC
 msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_SELFCHARGING.DESC"
 msgid ""
@@ -1722,17 +1731,20 @@ msgid ""
 "\n"
 "Its low <link=\"POWER\">wattage</link> and high <link=\"RADIATION\">Radioactivity</link> make it unsuitable for Bionic Duplicant use."
 msgstr ""
-"<link=\"ENRICHEDURANIUM\">濃縮ウラン</link>から作られた、セルフ充電式の<link=\"ELECTROBANK\">電力バンク</link>です。\n"
+"<link=\"ENRICHEDURANIUM\">濃縮ウラン</link>から作られた、自己充電式の<link=\"ELECTROBANK\">電力バンク</link>です。\n"
 "\n"
 "<link=\"LARGEELECTROBANKDISCHARGER\">大型放電器</link>または<link=\"SMALLELECTROBANKDISCHARGER\">コンパクト放電器</link>経由で設備に給電できます。\n"
 "\n"
-"<link=\"POWER\">ワット数</link>が低く<link=\"RADIATION\">放射能</link>が高いため、バイオニック複製人間への使用には適していません。"
+"<link=\"POWER\">ワット数</link>が低く<link=\"RADIATION\">放射能</link>が高いため、バイオニック複製人間への使用には適していません。\n"
+"\n"
+"水には濡らさないでください。"
 
 #. STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_SELFCHARGING.NAME
 msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_SELFCHARGING.NAME"
 msgid "<link=\"ELECTROBANKSELFCHARGING\">Atomic Power Bank</link>"
 msgstr "<link=\"ELECTROBANKSELFCHARGING\">原子力 電力バンク</link>"
 
+# ウラン鉱石 電力バンクのリンク先は"ELECTROBANKURANIUMORE"
 #. STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_URANIUM_ORE.DESC
 msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_URANIUM_ORE.DESC"
 msgid ""
@@ -1748,9 +1760,9 @@ msgstr ""
 "\n"
 "<link=\"LARGEELECTROBANKDISCHARGER\">大型放電器</link>または<link=\"SMALLELECTROBANKDISCHARGER\">コンパクト放電器</link>経由で設備に給電できます。\n"
 "\n"
-"複製人間は<link=\"CRAFTINGTABLE\">工作端末</link>で新しい<link=\"ELECTROBANK\">ウラン鉱石電力バンク</link>を生産できます。\n"
+"複製人間は<link=\"CRAFTINGTABLE\">工作端末</link>で新しい<link=\"ELECTROBANKURANIUMORE\">ウラン鉱石 電力バンク</link>を製作できます。\n"
 "\n"
-"湿気が天敵です。"
+"水には濡らさないでください。"
 
 #. STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_URANIUM_ORE.NAME
 msgctxt "STRINGS.ITEMS.INDUSTRIAL_PRODUCTS.ELECTROBANK_URANIUM_ORE.NAME"

--- a/po/misc.po
+++ b/po/misc.po
@@ -138,7 +138,7 @@ msgid ""
 msgstr ""
 "バイオニック複製人間が機能するためには<link=\"ELECTROBANK\">電力バンク</link>が必要です。<link=\"POWER\">電力</link>が切れると無力化し、他の複製人間の手によって再起動が必要になります。\n"
 "\n"
-"基本的な電力バンクは<link=\"CRAFTINGTABLE\">工作端末</link>で作成できます。"
+"基本的な電力バンクは<link=\"CRAFTINGTABLE\">工作端末</link>で製作できます。"
 
 #. STRINGS.MISC.NOTIFICATIONS.BIONICBATTERY.NAME
 msgctxt "STRINGS.MISC.NOTIFICATIONS.BIONICBATTERY.NAME"
@@ -1729,7 +1729,7 @@ msgstr "クリックしてこのアイテムの移動先を参照します"
 #. STRINGS.MISC.POPFX.EXTRA_POWERBANKS_BIONIC
 msgctxt "STRINGS.MISC.POPFX.EXTRA_POWERBANKS_BIONIC"
 msgid "Extra Power Banks"
-msgstr "予備電力バンク"
+msgstr "予備の電力バンク"
 
 # Hatchに床落ちアイテムを食べられたときのポップアップ
 #. STRINGS.MISC.POPFX.RESOURCE_EATEN
@@ -1888,19 +1888,20 @@ msgid ""
 "\n"
 "When lifetime reaches zero, this  <link=\"ELECTROBANK\">Power Bank</link> will explode"
 msgstr ""
-"セルフ充電は{0}間継続します\n"
+"自己充電は{0}のあいだ継続します\n"
 "\n"
-"寿命がゼロになると、この<link=\"ELECTROBANK\">電力バンク</link>は爆発します"
+"寿命が尽きると、この<link=\"ELECTROBANK\">電力バンク</link>は爆発します"
 
+# {0}はワット数
 #. STRINGS.MISC.STATUSITEMS.ELECTROBANKSELFCHARGING.NAME
 msgctxt "STRINGS.MISC.STATUSITEMS.ELECTROBANKSELFCHARGING.NAME"
 msgid "Self-Charging: {0}"
-msgstr "セルフ充電中: {charge}"
+msgstr "自己充電中: {0}"
 
 #. STRINGS.MISC.STATUSITEMS.ELECTROBANKSELFCHARGING.TOOLTIP
 msgctxt "STRINGS.MISC.STATUSITEMS.ELECTROBANKSELFCHARGING.TOOLTIP"
 msgid "This <link=\"ELECTROBANK\">Power Bank</link> is always slowly charging itself"
-msgstr "この<link=\"ELECTROBANK\">電力バンク</link>は常にゆっくり充電中です。"
+msgstr "この<link=\"ELECTROBANK\">電力バンク</link>は自身の機能で常にゆっくりと充電されます"
 
 #. STRINGS.MISC.STATUSITEMS.ELEMENTALCATEGORY.NAME
 msgctxt "STRINGS.MISC.STATUSITEMS.ELEMENTALCATEGORY.NAME"
@@ -2786,7 +2787,7 @@ msgstr "<link=\"LIGHT\">光源</link>"
 #. STRINGS.MISC.TAGS.EMPTYPORTABLEBATTERY
 msgctxt "STRINGS.MISC.TAGS.EMPTYPORTABLEBATTERY"
 msgid "<link=\"ELECTROBANKEMPTY\">Empty Eco Power Banks</link>"
-msgstr "<link=\"ELECTROBANKEMPTY\">空のエコ電力バンク</link>"
+msgstr "<link=\"ELECTROBANKEMPTY\">空のエコ 電力バンク</link>"
 
 #. STRINGS.MISC.TAGS.EXTRUDABLE
 msgctxt "STRINGS.MISC.TAGS.EXTRUDABLE"

--- a/po/research.po
+++ b/po/research.po
@@ -184,32 +184,32 @@ msgstr "<style=\"KKeyword\">材料工学研究</style>能力"
 #. STRINGS.RESEARCH.OTHER_TECH_ITEMS.DISPOSABLE_ELECTROBANK_METAL_ORE.DESC
 msgctxt "STRINGS.RESEARCH.OTHER_TECH_ITEMS.DISPOSABLE_ELECTROBANK_METAL_ORE.DESC"
 msgid "Enables fabrication of <style=\"KKeyword\">Metal Power Banks</style> at the <link=\"CRAFTINGTABLE\">Crafting Station</link>"
-msgstr "<link=\"CRAFTINGTABLE\">工作端末</link>で<style=\"KKeyword\">金属電力バンク</style>を製作できます"
+msgstr "<link=\"CRAFTINGTABLE\">工作端末</link>で<style=\"KKeyword\">メタル 電力バンク</style>を製作できます"
 
 #. STRINGS.RESEARCH.OTHER_TECH_ITEMS.DISPOSABLE_ELECTROBANK_METAL_ORE.NAME
 msgctxt "STRINGS.RESEARCH.OTHER_TECH_ITEMS.DISPOSABLE_ELECTROBANK_METAL_ORE.NAME"
 msgid "<style=\"KKeyword\">Metal Power Bank</style> Pattern"
-msgstr "<style=\"KKeyword\">金属電力バンク</style>パターン"
+msgstr "<style=\"KKeyword\">メタル 電力バンク</style>パターン"
 
 #. STRINGS.RESEARCH.OTHER_TECH_ITEMS.DISPOSABLE_ELECTROBANK_URANIUM_ORE.DESC
 msgctxt "STRINGS.RESEARCH.OTHER_TECH_ITEMS.DISPOSABLE_ELECTROBANK_URANIUM_ORE.DESC"
 msgid "Enables fabrication of <style=\"KKeyword\">Uranium Ore Power Banks</style> at the <link=\"CRAFTINGTABLE\">Crafting Station</link>"
-msgstr "<link=\"CRAFTINGTABLE\">工作端末</link>で<style=\"KKeyword\">ウラン鉱石電力バンク</style>を製作できます"
+msgstr "<link=\"CRAFTINGTABLE\">工作端末</link>で<style=\"KKeyword\">ウラン鉱石 電力バンク</style>を製作できます"
 
 #. STRINGS.RESEARCH.OTHER_TECH_ITEMS.DISPOSABLE_ELECTROBANK_URANIUM_ORE.NAME
 msgctxt "STRINGS.RESEARCH.OTHER_TECH_ITEMS.DISPOSABLE_ELECTROBANK_URANIUM_ORE.NAME"
 msgid "<style=\"KKeyword\">Uranium Ore Power Bank</style> Pattern"
-msgstr "<style=\"KKeyword\">ウラン鉱石電力バンク</style>パターン"
+msgstr "<style=\"KKeyword\">ウラン鉱石 電力バンク</style>パターン"
 
 #. STRINGS.RESEARCH.OTHER_TECH_ITEMS.ELECTROBANK.DESC
 msgctxt "STRINGS.RESEARCH.OTHER_TECH_ITEMS.ELECTROBANK.DESC"
 msgid "Enables fabrication of <style=\"KKeyword\">Eco Power Banks</style> at the <link=\"ADVANCEDCRAFTINGTABLE\">Soldering Station</link>"
-msgstr "<link=\"ADVANCEDCRAFTINGTABLE\">はんだ付け端末</link>で<style=\"KKeyword\">エコ電力バンク</style>を製作できます"
+msgstr "<link=\"ADVANCEDCRAFTINGTABLE\">はんだ付け端末</link>で<style=\"KKeyword\">エコ 電力バンク</style>を製作できます"
 
 #. STRINGS.RESEARCH.OTHER_TECH_ITEMS.ELECTROBANK.NAME
 msgctxt "STRINGS.RESEARCH.OTHER_TECH_ITEMS.ELECTROBANK.NAME"
 msgid "<style=\"KKeyword\">Eco Power Bank</style> Pattern"
-msgstr "<style=\"KKeyword\">エコ電力バンク</style>パターン"
+msgstr "<style=\"KKeyword\">エコ 電力バンク</style>パターン"
 
 #. STRINGS.RESEARCH.OTHER_TECH_ITEMS.EXCAVATIONBOOSTER.DESC
 msgctxt "STRINGS.RESEARCH.OTHER_TECH_ITEMS.EXCAVATIONBOOSTER.DESC"
@@ -356,12 +356,12 @@ msgstr "<style=\"KKeyword\">研究ブースター</style>パターン"
 #. STRINGS.RESEARCH.OTHER_TECH_ITEMS.SELFCHARGINGELECTROBANK.DESC
 msgctxt "STRINGS.RESEARCH.OTHER_TECH_ITEMS.SELFCHARGINGELECTROBANK.DESC"
 msgid "Enables fabrication of <style=\"KKeyword\">Atomic Power Bank</style> at the <link=\"SUPERMATERIALREFINERY\">Molecular Forge</link>"
-msgstr "<link=\"SUPERMATERIALREFINERY\">分子合成機</link>で<style=\"KKeyword\">原子力電力バンク</style>を製作できます"
+msgstr "<link=\"SUPERMATERIALREFINERY\">分子合成機</link>で<style=\"KKeyword\">原子力 電力バンク</style>を製作できます"
 
 #. STRINGS.RESEARCH.OTHER_TECH_ITEMS.SELFCHARGINGELECTROBANK.NAME
 msgctxt "STRINGS.RESEARCH.OTHER_TECH_ITEMS.SELFCHARGINGELECTROBANK.NAME"
 msgid "<style=\"KKeyword\">Atomic Power Bank</style> Pattern"
-msgstr "<style=\"KKeyword\">原子力電力バンク</style>パターン"
+msgstr "<style=\"KKeyword\">原子力 電力バンク</style>パターン"
 
 #. STRINGS.RESEARCH.OTHER_TECH_ITEMS.STRENGTHBOOSTER.DESC
 msgctxt "STRINGS.RESEARCH.OTHER_TECH_ITEMS.STRENGTHBOOSTER.DESC"


### PR DESCRIPTION
さまざまな種類の`電力バンク`の名称について、表記を統一しました。
素材名との間にある半角の空白があったりなかったりしたので、ひとまずあるほうに寄せています。

- `self-charging`
EV自動車の記事などでは`自己充電`と書かれているものが多い。

- `電力バンク`の水濡れについて
`水`を主成分とする`液体`に漬かると破損しますが、`石油`などでは平気でした。
`蒸気`でも影響がなかったので、注意書きには水分ではなく`水`と明記しています。
なぜか`原子力 電力バンク`の説明文には水濡れについて記載がないですが、普通に破損します。