### PR TITLE
Full Steam Ahead の訳について

### DIFF
--- a/po/buildings.po
+++ b/po/buildings.po
@@ -5559,8 +5559,9 @@ msgstr "<link=\"GENETICANALYSISSTATION\">植物分析機</link>"
 #. STRINGS.BUILDINGS.PREFABS.GEOTHERMALCONTROLLER.DESC
 msgctxt "STRINGS.BUILDINGS.PREFABS.GEOTHERMALCONTROLLER.DESC"
 msgid "What comes out depends very much on the initial temperature of what goes in."
-msgstr "出力されるものは、入力されたものの初期温度に大きく依存します。"
+msgstr "何が放出されるかは、注入した液体の初期温度に大きく依存します。"
 
+# Liquid: 地熱ヒートポンプに注入する液体素材(熱媒液)
 #. STRINGS.BUILDINGS.PREFABS.GEOTHERMALCONTROLLER.EFFECT
 msgctxt "STRINGS.BUILDINGS.PREFABS.GEOTHERMALCONTROLLER.EFFECT"
 msgid ""
@@ -5568,9 +5569,9 @@ msgid ""
 "\n"
 "Materials will be emitted at connected Geo Vents."
 msgstr ""
-"惑星の中心からの<link=\"HEAT\">熱</link>を使用して、<link=\"ELEMENTSLIQUID\">液体</link>の入力の温度を劇的に上昇させます。\n"
+"小惑星の中心核から伝わる<link=\"HEAT\">熱</link>を利用して、注入された<link=\"ELEMENTSLIQUID\">液体</link>素材の温度を劇的に上昇させます。\n"
 "\n"
-"接続された地熱噴出孔から素材が放出されます。"
+"素材は接続先の地熱噴出孔から放出されます。"
 
 #. STRINGS.BUILDINGS.PREFABS.GEOTHERMALCONTROLLER.NAME
 msgctxt "STRINGS.BUILDINGS.PREFABS.GEOTHERMALCONTROLLER.NAME"
@@ -5580,7 +5581,7 @@ msgstr "<link=\"GEOTHERMALCONTROLLER\">地熱ヒートポンプ</link>"
 #. STRINGS.BUILDINGS.PREFABS.GEOTHERMALVENT.BLOCKED_DESC
 msgctxt "STRINGS.BUILDINGS.PREFABS.GEOTHERMALVENT.BLOCKED_DESC"
 msgid "Blocked geo vents can be cleared by pumping in <link=\"ELEMENTSLIQUID\">liquids</link> that are hot enough to melt <link=\"LEAD\">Lead</link>."
-msgstr "詰まった地熱噴出孔は、<link=\"LEAD\">鉛</link>を溶かすほど高温の<link=\"ELEMENTSLIQUID\">液体</link>を使用すると解消できます。"
+msgstr "地熱噴出孔の詰まりは、<link=\"LEAD\">鉛</link>を溶かすほど高温の<link=\"ELEMENTSLIQUID\">液体</link>を配管に流し込むことで解消できます。"
 
 #. STRINGS.BUILDINGS.PREFABS.GEOTHERMALVENT.DESC
 msgctxt "STRINGS.BUILDINGS.PREFABS.GEOTHERMALVENT.DESC"
@@ -5590,12 +5591,12 @@ msgstr "地熱噴出孔は、新しい素材を受け入れる前に現在の放
 #. STRINGS.BUILDINGS.PREFABS.GEOTHERMALVENT.EFFECT
 msgctxt "STRINGS.BUILDINGS.PREFABS.GEOTHERMALVENT.EFFECT"
 msgid "Emits high-<link=\"HEAT\">temperature</link> materials received from the Geothermal Heat Pump."
-msgstr "地熱ヒートポンプから受け取った<link=\"HEAT\">高温</link>の素材を放出します。"
+msgstr "地熱ヒートポンプから圧送された<link=\"HEAT\">高温</link>の素材を放出します。"
 
 #. STRINGS.BUILDINGS.PREFABS.GEOTHERMALVENT.LOGIC_PORT
 msgctxt "STRINGS.BUILDINGS.PREFABS.GEOTHERMALVENT.LOGIC_PORT"
 msgid "Material Content Monitor"
-msgstr "素材コンテンツモニター"
+msgstr "中身の素材の監視"
 
 #. STRINGS.BUILDINGS.PREFABS.GEOTHERMALVENT.LOGIC_PORT_ACTIVE
 msgctxt "STRINGS.BUILDINGS.PREFABS.GEOTHERMALVENT.LOGIC_PORT_ACTIVE"
@@ -5636,7 +5637,7 @@ msgstr ""
 #. STRINGS.BUILDINGS.PREFABS.GEOTUNER.LOGIC_PORT
 msgctxt "STRINGS.BUILDINGS.PREFABS.GEOTUNER.LOGIC_PORT"
 msgid "Geyser Eruption Monitor"
-msgstr "間欠泉噴出モニター"
+msgstr "間欠泉噴出の監視"
 
 #. STRINGS.BUILDINGS.PREFABS.GEOTUNER.LOGIC_PORT_ACTIVE
 msgctxt "STRINGS.BUILDINGS.PREFABS.GEOTUNER.LOGIC_PORT_ACTIVE"

--- a/po/colony_achievements.po
+++ b/po/colony_achievements.po
@@ -22,15 +22,18 @@ msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACHIEVED_THIS_COLONY_TOOLTIP"
 msgid "The current colony fulfilled this Initiative"
 msgstr "現在のコロニーはこの取り組みを達成しています"
 
+# Reconnect: ヒートポンプの配管システムを鋼鉄で修復して噴出孔と繫げること
+# Pipes: 地熱ヒートポンプと地熱噴出孔を繫げる配管システム。配管設備の「液体パイプ」とは別物。ゲーム画面には現れない。
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.CANCEL_REPAIR_CONTROLLER_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.CANCEL_REPAIR_CONTROLLER_TITLE"
 msgid "Cancel Reconnect Pipes"
-msgstr "パイプの再接続を中断"
+msgstr "配管システムの修復をやめる"
 
+# Reconnect: ヒートポンプの配管システムを鋼鉄で修復して噴出孔と繫げること
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.CANCEL_REPAIR_CONTROLLER_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.CANCEL_REPAIR_CONTROLLER_TOOLTIP"
 msgid "Cancel reconnect pipes order"
-msgstr "パイプの再接続指示を取り消します"
+msgstr "配管システムの修復指示を取り消します"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.CANCEL_UNCOVER_VENT_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.CANCEL_UNCOVER_VENT_TITLE"
@@ -45,53 +48,58 @@ msgstr "間欠泉の発掘指示を取り消します"
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.DISCONNECT_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.DISCONNECT_TITLE"
 msgid "Disconnect"
-msgstr "切断"
+msgstr "切断する"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.DISCONNECT_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.DISCONNECT_TOOLTIP"
 msgid "Disconnect this geo vent from the geothermal heat pump {Hotkey}"
 msgstr "この地熱噴出孔を地熱ヒートポンプから切断します {Hotkey}"
 
+# materials: 地熱ヒートポンプに注入する液体素材(熱媒液)
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.INITIATE_FIRST_VENT_FILLING_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.INITIATE_FIRST_VENT_FILLING_TOOLTIP"
 msgid "Insufficient materials"
-msgstr "素材不足"
+msgstr "<style=\"KKeyword\">液体</style>素材の注入が足りません"
 
+# Liquids: 地熱ヒートポンプに注入した液体素材(熱媒液)
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.INITIATE_FIRST_VENT_READY_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.INITIATE_FIRST_VENT_READY_TOOLTIP"
 msgid "Release <style=\"KKeyword\">Liquids</style> from the geothermal heat pump to the geo vents for the first time"
-msgstr "初めて<style=\"KKeyword\">液体</style>を地熱ヒートポンプから地熱噴出孔に放出します"
+msgstr "地熱ヒートポンプから地熱噴出孔へ、初めて<style=\"KKeyword\">液体</style>素材を圧送します"
 
+# このボタンを押すと「地熱発電所の起動」の条件が達成される
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.INITIATE_FIRST_VENT_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.INITIATE_FIRST_VENT_TITLE"
 msgid "Activate Power Plant"
-msgstr "電力設備起動"
+msgstr "発電所を起動する"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.INITIATE_FIRST_VENT_UNAVAILABLE_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.INITIATE_FIRST_VENT_UNAVAILABLE_TOOLTIP"
 msgid "No connected vents are currently ready to accept materials"
-msgstr "接続中の噴出孔は素材を受け入れる準備が出来ていません"
+msgstr "準備完了した噴出孔との接続がありません"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.RECONNECT_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.RECONNECT_TITLE"
 msgid "Reconnect"
-msgstr "再接続"
+msgstr "再接続する"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.RECONNECT_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.RECONNECT_TOOLTIP"
 msgid "Reconnect this geo vent to the geothermal heat pump {Hotkey}"
 msgstr "この地熱噴出孔を地熱ヒートポンプに再接続します {Hotkey}"
 
+# Reconnect: ヒートポンプの配管システムを鋼鉄で修復して噴出孔と繫げること
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.REPAIR_CONTROLLER_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.REPAIR_CONTROLLER_TITLE"
 msgid "Reconnect Heat Pump"
-msgstr "ヒートポンプ再接続"
+msgstr "配管システムを修復させる"
 
 # この設備に鋼鉄を与えることで、配管システムを利用できるようになる。
+# Reconnect: ヒートポンプの配管システムを鋼鉄で修復して噴出孔と繫げること
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.REPAIR_CONTROLLER_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.BUTTONS.REPAIR_CONTROLLER_TOOLTIP"
 msgid "Reconnect this building's  <style=\"KKeyword\">Steel</style> plumbing system to restore function"
-msgstr "この設備の<style=\"KKeyword\">鋼鉄</style>製配管システムを再接続して機能を回復します"
+msgstr "この設備の配管システムを<style=\"KKeyword\">鋼鉄</style>で修復し、機能を回復します"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.DESCRIPTION
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.DESCRIPTION"
@@ -107,11 +115,11 @@ msgid ""
 "\n"
 "I am hopeful that we have learned enough to wield this machinery more wisely than those who came before us."
 msgstr ""
-"道のりは長く、乗り越えられないと思われる課題が数多くあったが、我々はこの惑星の核となる潜在能力を活用することに成功した。\n"
+"道のりは長く、乗り越えることは不可能とも思える困難にたびたび見舞われたが、我々はこの小惑星の核に秘められた力を引き出すことに成功した。\n"
 "\n"
-"我々は今、持続可能な電力供給の未来の最先端に誇りを持って立っており...とても謙虚な気持ちだ。\n"
+"我々は今、持続可能なエネルギー社会という未来へ向けた正念場に、誇らしく立っている...実に身の引き締まる思いだ。\n"
 "\n"
-"先人たちよりも賢くこの機械を扱えるだけの知識を我々が備えていることを願っている。"
+"我々の学んできたことが、この機械を先人たち以上に賢く扱うのに十分なものであると願っている。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.MESSAGE_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.MESSAGE_TITLE"
@@ -126,27 +134,28 @@ msgstr "心からの敬意を"
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.NAME"
 msgid "Full Steam Ahead"
-msgstr "全速前進"
+msgstr "蒸気全開"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.NOTIFICATIONS.GEOTHERMAL_PLANT_FIRST_VENT_READY
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.NOTIFICATIONS.GEOTHERMAL_PLANT_FIRST_VENT_READY"
 msgid "Geothermal Power Plant: Initiate"
-msgstr "地熱発電所: 開始"
+msgstr "地熱発電所: 起動"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.NOTIFICATIONS.GEOTHERMAL_PLANT_FIRST_VENT_READY_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.NOTIFICATIONS.GEOTHERMAL_PLANT_FIRST_VENT_READY_TOOLTIP"
 msgid "The geothermal power plant is ready to be activated"
-msgstr "地熱発電所は起動準備ができています"
+msgstr "地熱発電所は起動する準備ができています"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.NOTIFICATIONS.GEOTHERMAL_PLANT_RECONNECTED
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.NOTIFICATIONS.GEOTHERMAL_PLANT_RECONNECTED"
 msgid "Geothermal Heat Pump: Ready"
-msgstr "地熱ヒートポンプ: 利用可能"
+msgstr "地熱ヒートポンプ: 準備完了"
 
+# materials: 地熱ヒートポンプに注入する液体素材(熱媒液)
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.NOTIFICATIONS.GEOTHERMAL_PLANT_RECONNECTED_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.NOTIFICATIONS.GEOTHERMAL_PLANT_RECONNECTED_TOOLTIP"
 msgid "The geothermal heat pump is ready to receive materials"
-msgstr "地熱ヒートポンプは素材を受け入れる準備ができています"
+msgstr "地熱ヒートポンプは<style=\"KKeyword\">液体</style>素材を注入する準備ができています"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.POPUPS.GEOPLANT_ERRUPTED_DESC
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.POPUPS.GEOPLANT_ERRUPTED_DESC"
@@ -157,16 +166,16 @@ msgid ""
 "\n"
 "My Duplicants seem keen to commemorate this accomplishment by keeping the obstruction as something of a trophy."
 msgstr ""
-"複製人間達は地熱噴出孔の障害物を全て取り去った！\n"
+"複製人間たちは地熱噴出孔の詰まりを解消することに成功した！\n"
 "\n"
-"これでこの強大な熱源と電力源の潜在的能力を最大限に引き出すことができる。入力温度の調整次第では興味深い二次副産物を得られることもあるだろう。\n"
+"これで、この強大な熱エネルギー源に秘められた力を最大限に引き出すことができる。注入温度の調整次第では、さらに興味深い副産物を得ることもできるだろう。\n"
 "\n"
-"複製人間達は取り除いた障害物をトロフィーのように飾ることで成果を記念することに熱心なようだ。"
+"複製人間たちは詰まっていた塊をトロフィーのように飾ることで、この偉業を記念したいと考えているようだ。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.POPUPS.GEOPLANT_ERRUPTED_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.POPUPS.GEOPLANT_ERRUPTED_TITLE"
 msgid "Completed: Geothermal Power Plant"
-msgstr "地熱発電完了"
+msgstr "完了: 地熱発電所"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.POPUPS.GEOTHERMAL_DISCOVERED_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.POPUPS.GEOTHERMAL_DISCOVERED_TITLE"
@@ -184,9 +193,9 @@ msgid ""
 msgstr ""
 "放棄された地熱発電所を発見した！\n"
 "\n"
-"スキャンによると、この施設は惑星全体にある複数の建物で構成されており、配管は地形に深く埋め込まれているため、その大部分は私たちの手の届かないところにあるようだ。\n"
+"探査結果によれば、この施設は小惑星内に点在する複数の設備で構成されており、配管は地形に深く埋め込まれているため、その大部分は我々の手の届かないところにあるようだ。\n"
 "\n"
-"アクセス可能な部分のほとんどは、かなり機能的に見える。"
+"手の届く部分に関しては、そのほとんどが完全に機能しているように見える。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.POPUPS.GEOTHERMAL_PLANT_REPAIRED_DESC
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.POPUPS.GEOTHERMAL_PLANT_REPAIRED_DESC"
@@ -197,62 +206,70 @@ msgid ""
 "\n"
 "The vents also emit various byproducts. I'm sure I can find a use for them."
 msgstr ""
-"成功だ！複製人間達が地熱ヒートポンプの配管システムを無事修復した。\n"
+"成功だ！複製人間たちが地熱ヒートポンプの配管システムを無事に修復した。\n"
 "\n"
-"これで、この設備を使用して、接続された地熱噴出孔に液体を送り出すことができる。通気孔に蒸気タービンを建築すれば、発生した蒸気を電力に変換できるだろう。\n"
+"これで、この設備を使用して接続先の地熱噴出孔へ液体を圧送することができる。噴出孔のある場所に蒸気タービンを設置すれば、発生した蒸気を電力に変換できるだろう。\n"
 "\n"
-"通気孔からはさまざまな副産物も排出される。これらにもきっと使い道が見つかるはずだ。"
+"噴出孔からは、さまざまな副産物も放出される。これらにもきっと使い道が見つかるはずだ。"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.POPUPS.GEOTHERMAL_PLANT_REPAIRED_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.POPUPS.GEOTHERMAL_PLANT_REPAIRED_TITLE"
 msgid "Progress Report: Geothermal Power Plant"
 msgstr "進捗報告: 地熱発電所"
 
+# ☑実績の達成条件
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.ACTIVATE_PLANT_DESCRIPTION
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.ACTIVATE_PLANT_DESCRIPTION"
 msgid "Pump <style=\"KKeyword\">liquids</style> from the Geothermal Heat Pump into the Geo Vents"
-msgstr "地熱ヒートポンプから<style=\"KKeyword\">液体</style>を汲み出し地熱噴出孔に放出する"
+msgstr "地熱ヒートポンプから地熱噴出孔へ<style=\"KKeyword\">液体</style>を圧送する"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.ACTIVATE_PLANT_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.ACTIVATE_PLANT_TITLE"
 msgid "Operate Geothermal Power Plant"
-msgstr "地熱発電所の操作"
+msgstr "地熱発電所の起動"
 
+# ☑実績の達成条件
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.DISCOVER_GEOTHERMAL_FACILITY_DESCRIPTION
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.DISCOVER_GEOTHERMAL_FACILITY_DESCRIPTION"
 msgid "Discover the geothermal power plant buildings"
-msgstr "地熱発電所設備を発見する"
+msgstr "地熱発電所の設備を発見する"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.DISCOVER_GEOTHERMAL_FACILITY_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.DISCOVER_GEOTHERMAL_FACILITY_TITLE"
 msgid "Discover Geothermal Power Plant"
-msgstr "地熱発電所を発見"
+msgstr "地熱発電所の発見"
 
+# ☑実績の達成条件
+# Reconnect: ヒートポンプの配管システムを鋼鉄で修復して噴出孔と繫げること
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.REPAIR_CONTROLLER_DESCRIPTION
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.REPAIR_CONTROLLER_DESCRIPTION"
 msgid "Reconnect the Geothermal Heat Pump's plumbing"
-msgstr "地熱ヒートポンプの配管を再接続する"
+msgstr "地熱ヒートポンプの配管システムを修復する"
 
+# Reconnect: ヒートポンプの配管システムを鋼鉄で修復して噴出孔と繫げること
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.REPAIR_CONTROLLER_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.REPAIR_CONTROLLER_TITLE"
 msgid "Reconnect Geothermal Heat Pump"
-msgstr "地熱ヒートポンプを再接続"
+msgstr "地熱ヒートポンプの修復"
 
+# ☑実績の達成条件
+# 実際は、詰まりを解消した時点で実績解除になる(発電は不要)
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.UNBLOCK_VENT_DESCRIPTION
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.UNBLOCK_VENT_DESCRIPTION"
 msgid "Clear the blocked Geo Vent to maximize the geothermal power plant's efficiency"
-msgstr "地熱発電所の効率を最大化するために地熱噴出孔の障害物を除去する"
+msgstr "地熱噴出孔の詰まりを解消し、地熱発電所の出力を最大にする"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.UNBLOCK_VENT_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.REQUIREMENTS.UNBLOCK_VENT_TITLE"
 msgid "Clear Blocked Geo Vent"
-msgstr "地熱噴出孔の保全"
+msgstr "地熱噴出孔の詰まり解消"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.BRING_CONTROLLER_ONLINE_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.BRING_CONTROLLER_ONLINE_TITLE"
 msgid "Enable <link=\"unused\">Geothermal Heat Pump</link>"
 msgstr "<link=\"unused\">地熱ヒートポンプ</link>有効化"
 
+# Reconnect: ヒートポンプの配管システムを鋼鉄で修復して噴出孔と繫げること
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.BRING_CONTROLLER_ONLINE_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.BRING_CONTROLLER_ONLINE_TOOLTIP"
 msgid ""
@@ -260,7 +277,7 @@ msgid ""
 "\n"
 "Click to show this building"
 msgstr ""
-"この設備の<style=\"KKeyword\">鋼鉄</style>製配管システムを再接続して機能を回復します\n"
+"この設備の配管システムを<style=\"KKeyword\">鋼鉄</style>で修復し、機能を回復します\n"
 "\n"
 "クリックして設備を表示します"
 
@@ -272,12 +289,12 @@ msgstr ""
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.BRING_ONLINE_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.BRING_ONLINE_TITLE"
 msgid "Reclaim Power Plant"
-msgstr "発電所再利用"
+msgstr "発電所の復旧"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.BRING_VENT_ONLINE_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.BRING_VENT_ONLINE_TITLE"
 msgid "Enable <link=\"{Target}\">{Name}</link>"
-msgstr "<link=\"{Target}\">{Name}</link>有効化"
+msgstr "<link=\"{Target}\">{Name}</link>を有効にする"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.BRING_VENT_ONLINE_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.BRING_VENT_ONLINE_TOOLTIP"
@@ -293,7 +310,7 @@ msgstr ""
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.UTILIZE_GEOPLANT_DESC
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.UTILIZE_GEOPLANT_DESC"
 msgid "Successfully heat a <style=\"KKeyword\">Liquid</style> via the geothermal heat pump for the first time"
-msgstr "初めて地熱ヒートポンプ経由で<style=\"KKeyword\">液体</style>の加熱に成功する"
+msgstr "初めて地熱ヒートポンプで<style=\"KKeyword\">液体</style>素材の加熱に成功する"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.UTILIZE_GEOPLANT_TITLE
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.SIDESCREENS.UTILIZE_GEOPLANT_TITLE"
@@ -303,7 +320,7 @@ msgstr "起動実験完了"
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.CANNOT_PUSH_ENTOMBED_VENT_NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.CANNOT_PUSH_ENTOMBED_VENT_NAME"
 msgid "Geo Vent Entombed"
-msgstr "地熱噴出孔埋没"
+msgstr "地熱噴出孔が埋没"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.CANNOT_PUSH_ENTOMBED_VENT_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.CANNOT_PUSH_ENTOMBED_VENT_TOOLTIP"
@@ -314,26 +331,26 @@ msgid ""
 "\n"
 "Click here to show this vent"
 msgstr ""
-"接続された地熱噴出孔が埋没しています\n"
+"接続先の地熱噴出孔が埋没しています\n"
 "\n"
-"この設備が機能するためには全ての地熱噴出孔が利用可能になっている必要があります\n"
+"この設備が動作するには、接続された全ての地熱噴出孔が準備を完了している必要があります\n"
 "\n"
 "クリックして噴出孔を表示"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.CANNOT_PUSH_NO_CONNECTED_NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.CANNOT_PUSH_NO_CONNECTED_NAME"
 msgid "No Geo Vents Connected"
-msgstr "地熱噴出孔未接続"
+msgstr "地熱噴出孔が未接続"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.CANNOT_PUSH_NO_CONNECTED_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.CANNOT_PUSH_NO_CONNECTED_TOOLTIP"
 msgid "This building must be connected to at least one geo vent in order to function"
-msgstr "この設備が動作するには最低一つの地熱噴出孔が接続されている必要があります"
+msgstr "この設備が動作するには、1つ以上の地熱噴出孔と接続されている必要があります"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.CANNOT_PUSH_UNREADY_CONNECTION_NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.CANNOT_PUSH_UNREADY_CONNECTION_NAME"
 msgid "Geo Vent Unavailable"
-msgstr "地熱噴出孔利用不可"
+msgstr "地熱噴出孔が利用不可"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.CANNOT_PUSH_UNREADY_CONNECTION_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.CANNOT_PUSH_UNREADY_CONNECTION_TOOLTIP"
@@ -344,31 +361,35 @@ msgid ""
 "\n"
 "Click here to show this vent"
 msgstr ""
-"接続された地熱噴出孔が現在利用不可能です\n"
+"接続先の地熱噴出孔が準備を完了していません\n"
 "\n"
-"この設備が機能するためには全ての地熱噴出孔が利用可能になっている必要があります\n"
+"この設備が動作するには、接続された全ての地熱噴出孔が準備を完了している必要があります\n"
 "\n"
 "クリックして噴出孔を表示"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.OFFLINE_NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.OFFLINE_NAME"
 msgid "Offline"
-msgstr "オフライン"
+msgstr "配管なし"
 
+# Reconnect: ヒートポンプの配管システムを鋼鉄で修復して噴出孔と繫げること
+# materials: 地熱ヒートポンプに注入する液体素材(熱媒液)
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.OFFLINE_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.OFFLINE_TOOLTIP"
 msgid "This building's plumbing must be reconnected before it can receive materials"
-msgstr "この設備が素材を受け入れるためには配管を再接続する必要があります"
+msgstr "この設備に<style=\"KKeyword\">液体</style>素材を注入するには、配管システムを修復する必要があります"
 
+# Reconnect: ヒートポンプの配管システムを鋼鉄で修復して噴出孔と繫げること
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.PENDING_RECONNECTION_NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.PENDING_RECONNECTION_NAME"
 msgid "Pending Reconnect"
-msgstr "再接続待ち"
+msgstr "修復作業待ち"
 
+# Reconnect: ヒートポンプの配管システムを鋼鉄で修復して噴出孔と繫げること
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.PENDING_RECONNECTION_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.PENDING_RECONNECTION_TOOLTIP"
 msgid "Waiting for a Duplicant to reconnect the plumbing"
-msgstr "複製人間による配管再接続待ちです"
+msgstr "複製人間による配管システムの修復を待っています"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.STORAGE_STATUS_NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.CONTROLLER.STORAGE_STATUS_NAME"
@@ -382,7 +403,7 @@ msgid ""
 "\n"
 "Current pressure: {Amount}/{Threshold}"
 msgstr ""
-"圧力が {Threshold} に到達すると、この設備の内容物は加熱され配管を通じて接続された地熱噴出孔に放出されます\n"
+"圧力が {Threshold} に到達すると、この設備の内容物は加熱され、配管システムを通じて接続された地熱噴出孔へ圧送されます\n"
 "\n"
 "現在の圧力: {Amount}/{Threshold}"
 
@@ -398,24 +419,25 @@ msgid ""
 "\n"
 "The initial input <style=\"KKeyword\">Temperature</style> determines the type of materials emitted"
 msgstr ""
-"この設備内の<style=\"KKeyword\">液体</style>平均<style=\"KKeyword\">温度</style>は {Temp} です\n"
+"この設備に注入した<style=\"KKeyword\">液体</style>素材の平均<style=\"KKeyword\">温度</style>は {Temp} です\n"
 "\n"
-"液体入力時の初期<style=\"KKeyword\">温度</style>は放出時の素材に影響します"
+"注入した液体の初期<style=\"KKeyword\">温度</style>によって、地熱噴出孔から放出される素材の種類が決まります"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.BLOCKED_NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.BLOCKED_NAME"
 msgid "Blocked"
-msgstr "妨害されている"
+msgstr "詰まっている"
 
+# Pipes: 地熱ヒートポンプと地熱噴出孔を繫げる配管システム。配管設備の「液体パイプ」とは別物。ゲーム画面には現れない。
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.BLOCKED_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.BLOCKED_TOOLTIP"
 msgid "A <style=\"KKeyword\">Pipe</style> has been obstructed and is preventing <style=\"KKeyword\">Liquids</style> or <style=\"KKeyword\">Gases</style> from flowing to this geo vent"
-msgstr "<style=\"KKeyword\">パイプ</style>が詰まっているため、排水口から<style=\"KKeyword\">液体</style>または<style=\"KKeyword\">気体</style>を地熱噴出孔に放出できません"
+msgstr "<style=\"KKeyword\">配管システム</style>が詰まっているため、<style=\"KKeyword\">液体</style>や<style=\"KKeyword\">気体</style>を地熱噴出孔へ圧送できません"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.DISCONNECTED_NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.DISCONNECTED_NAME"
 msgid "Disconnected"
-msgstr "未接続"
+msgstr "切断"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.DISCONNECTED_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.DISCONNECTED_TOOLTIP"
@@ -426,7 +448,7 @@ msgid ""
 msgstr ""
 "この地熱噴出孔は地熱ヒートポンプに接続されていません\n"
 "\n"
-"現在の状態では素材を受け入れることはできません"
+"現在の状態では、圧送される素材を受け入れることはできません"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.OVERPRESSURE_NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.OVERPRESSURE_NAME"
@@ -442,9 +464,9 @@ msgid ""
 "\n"
 "Click here to show this vent"
 msgstr ""
-"このエリアにある高圧の<style=\"KKeyword\">液体</style>または<style=\"KKeyword\">気体</style>が放出を妨害しています\n"
+"この区域にある高圧の<style=\"KKeyword\">液体</style>や<style=\"KKeyword\">気体</style>が素材の放出を妨げています\n"
 "\n"
-"<style=\"KKeyword\">液体</style>または<style=\"KKeyword\">気体</style>を取り除いて減圧するか、空間を拡張してください\n"
+"<style=\"KKeyword\">液体</style>や<style=\"KKeyword\">気体</style>をポンプで排出するか、空間を拡張して減圧してください\n"
 "\n"
 "クリックして噴出孔を表示"
 
@@ -461,7 +483,7 @@ msgstr "複製人間はまもなくこの汚れた古い防水シートを取り
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.QUEST_BLOCKED_NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.QUEST_BLOCKED_NAME"
 msgid "Blocked"
-msgstr "妨害されている"
+msgstr "詰まっている"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.QUEST_BLOCKED_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.QUEST_BLOCKED_TOOLTIP"
@@ -470,19 +492,20 @@ msgid ""
 "\n"
 "It will become usable once the obstruction has been cleared by piping in liquids hot enough to melt it"
 msgstr ""
-"この地熱噴出孔は<style=\"KKeyword\">鉛</style>塊によって妨害されています\n"
+"この地熱噴出孔は<style=\"KKeyword\">鉛</style>の塊で塞がれています\n"
 "\n"
-"鉛が溶けるほど熱い液体を配管に流し込み、障害物を取り除けば使用可能になります"
+"鉛が溶けるほど熱い液体を配管に流し込んで詰まりを解消すれば、使用できるようになります"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.READY_NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.READY_NAME"
 msgid "Ready"
-msgstr "利用可能"
+msgstr "準備完了"
 
+# materials: 地熱ヒートポンプに注入した液体素材(熱媒液)
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.READY_TOOLTIP
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.READY_TOOLTIP"
 msgid "This geo vent is ready to recieve materials"
-msgstr "この地熱噴出孔は素材を受け入れる準備が整っています"
+msgstr "この地熱噴出孔は、地熱ヒートポンプから圧送される素材を受け入れる準備ができています"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.VENTING_NAME
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.ACTIVATEGEOTHERMALPLANT.STATUSITEMS.VENT.VENTING_NAME"
@@ -496,9 +519,9 @@ msgid ""
 "\n"
 "It has {Quantity} of materials left to emit before this process is complete"
 msgstr ""
-"この地熱噴出孔は現在素材を放出中です。\n"
+"現在、この地熱噴出孔は素材を放出中です\n"
 "\n"
-"このプロセスが完了するまで、素材を残り {Quantity} 放出します"
+"この活動が完了するまでに、{Quantity} の素材が放出されます"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.DISTANT_PLANET_REACHED.DESCRIPTION
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.DISTANT_PLANET_REACHED.DESCRIPTION"
@@ -1357,7 +1380,7 @@ msgstr "探査の必須事項を満たすことで過去を明らかにし、未
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.WINCONDITION_GEOTHERMAL
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.WINCONDITION_GEOTHERMAL"
 msgid "Full Steam Ahead"
-msgstr "全速前進"
+msgstr "蒸気全開"
 
 #. STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.WINCONDITION_GEOTHERMAL_DESCRIPTION
 msgctxt "STRINGS.COLONY_ACHIEVEMENTS.MISC_REQUIREMENTS.WINCONDITION_GEOTHERMAL_DESCRIPTION"

--- a/po/misc.po
+++ b/po/misc.po
@@ -1760,7 +1760,7 @@ msgstr "注意してください！"
 #. STRINGS.MISC.STATUSITEMS.ATTENTIONREQUIRED.TOOLTIP
 msgctxt "STRINGS.MISC.STATUSITEMS.ATTENTIONREQUIRED.TOOLTIP"
 msgid "Something in my colony needs to be attended to"
-msgstr "コロニーの何かしらに注意を必要としています"
+msgstr "コロニー内に注意を要する何かがあります"
 
 #. STRINGS.MISC.STATUSITEMS.AWAITINGSTUDY.NAME
 msgctxt "STRINGS.MISC.STATUSITEMS.AWAITINGSTUDY.NAME"

--- a/po/ui.po
+++ b/po/ui.po
@@ -11530,9 +11530,9 @@ msgid ""
 "\n"
 "Some things really <i>do</i> get better with age."
 msgstr ""
-"有機物が鉛に化石化した目を見張るサンプル。\n"
+"有機物が鉛に化石化した、目を見張るほど見事な標本です。\n"
 "\n"
-"年月とともによく<i>なる/i>ものも本当にある。"
+"年月を経ることで<i>本当に</i>その良さを増すものがあります。"
 
 #. STRINGS.UI.KEEPSAKES.GEOTHERMAL_PLANT.NAME
 msgctxt "STRINGS.UI.KEEPSAKES.GEOTHERMAL_PLANT.NAME"


### PR DESCRIPTION
Frosty DLC で新たに追加された実績 `Full Steam Ahead` の訳についてです。

これは蒸気船が走っていた時代の言葉で「全速前進せよ」「蒸気機関を全開にせよ」という意味で使われていたそうです。
「全開 / 蒸気 / 前へ」
「全開の蒸気で前へ（進め）」

この実績の解除条件は、小惑星内にある`地熱発電所`を発見して、`配管システム`(`plumbing system`)の詰まりを解消することです。（そうすることで`地熱発電所`が本来の性能を発揮できるようになる）
地熱発電所は`蒸気タービン`で発電することを想定された施設なので、それに当てはめると「蒸気を全開にしろ」といった感じの意味になると思います。

というわけで`蒸気全開`と訳してみました。
https://dictionary.goo.ne.jp/srch/all/full+steam/m0u/
よろしくお願いします。