### PR TITLE
出力調整の禁止/許可について

### DIFF
--- a/po/ui.po
+++ b/po/ui.po
@@ -29739,22 +29739,28 @@ msgstr "収納する素材を指定します"
 #. STRINGS.UI.USERMENUACTIONS.TINKER.ALLOW
 msgctxt "STRINGS.UI.USERMENUACTIONS.TINKER.ALLOW"
 msgid "Allow Tinker"
-msgstr "工具許可"
+msgstr "出力調整を許可する"
 
 #. STRINGS.UI.USERMENUACTIONS.TINKER.DISALLOW
 msgctxt "STRINGS.UI.USERMENUACTIONS.TINKER.DISALLOW"
 msgid "Disallow Tinker"
-msgstr "工具禁止"
+msgstr "出力調整を禁止する"
 
 #. STRINGS.UI.USERMENUACTIONS.TINKER.TOOLTIP_ALLOW
 msgctxt "STRINGS.UI.USERMENUACTIONS.TINKER.TOOLTIP_ALLOW"
 msgid "Allow  {0} on this {1}"
-msgstr "{0}をこの{1}に許可する"
+msgstr ""
+"この{1}への{0}を許可します\n"
+"\n"
+"現在の設定: <b><style=\"logic_off\">出力調整しない</style></b>"
 
 #. STRINGS.UI.USERMENUACTIONS.TINKER.TOOLTIP_DISALLOW
 msgctxt "STRINGS.UI.USERMENUACTIONS.TINKER.TOOLTIP_DISALLOW"
 msgid "Disallow {0} on this {1}"
-msgstr "{0}をこの{1}に禁止する"
+msgstr ""
+"この{1}への{0}を禁止します\n"
+"\n"
+"現在の設定: <b><style=\"logic_on\">出力調整する</style></b>"
 
 #. STRINGS.UI.USERMENUACTIONS.TRANSITTUBEWAX.NAME
 msgctxt "STRINGS.UI.USERMENUACTIONS.TRANSITTUBEWAX.NAME"


### PR DESCRIPTION
新たに追加されたUIである、発電機への`出力調整`(`Tune up`)の禁止/許可ボタンについてです。

切り替え式のボタン（トグルボタン）の名称は、現在の状態を表しているのか、ボタンを押すことで発生する効果なのか見分けづらいという問題があり、このボタンも例外ではないので、誤解のないようにしました。

`Tinker`は、電気工学のスキルを持った複製人間が工具を使って発電機の出力調整を行うことを表しているので、`Tune up`と同じ意味と理解して問題ないと思います。

よろしくお願いします。