### PR TITLE
chore: add no-wrap

### DIFF
--- a/concat.sh
+++ b/concat.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-msgcat po/*.po > strings.po
+msgcat --no-wrap po/*.po > strings.po


### PR DESCRIPTION
おそらくmsgcatのバージョンか実行環境の違いで、 @nsk4762jp さんの環境と少なくとも私の環境とでは、改行の箇所が異なるため出力結果が異なっていました。

`--no-wrap` を追加することで、一貫性のある出力が保証できるようになると思います
