### PR TITLE
ロケットの目的地の説明について

### DIFF
--- a/po/building.po
+++ b/po/building.po
@@ -1944,7 +1944,7 @@ msgstr ""
 #. STRINGS.BUILDING.STATUSITEMS.INFLIGHT.NAME
 msgctxt "STRINGS.BUILDING.STATUSITEMS.INFLIGHT.NAME"
 msgid "In Flight To {Destination_Asteroid}: {ETA}"
-msgstr "{Destination_Asteroid}へ向けて航行中: 残り {ETA}"
+msgstr "{Destination_Asteroid}へ航行中: 残り {ETA}"
 
 #. STRINGS.BUILDING.STATUSITEMS.INFLIGHT.TOOLTIP
 msgctxt "STRINGS.BUILDING.STATUSITEMS.INFLIGHT.TOOLTIP"


### PR DESCRIPTION
ロケットのステータスタブに表示される、目的地までの残り時間の説明文を修正しました。
日本語フォントは元フォントに比べて横幅が広く、表示範囲からはみ出してしまうため、なるべく短くしたいという趣旨です。

目的地となりうる小惑星は、名称が自動生成されるため、あまりに長いと数字もはみ出してしまうことがあります。
よろしくお願いします。
![Rocket](https://github.com/user-attachments/assets/9d3350ae-0609-4c87-86a2-272124ff606d)
